### PR TITLE
feat: 診断済みバッジ・履歴閲覧・2回上限を実装 (closes #1, closes #2)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -139,6 +139,42 @@ vercel --prod
 
 ---
 
+## 8. 診断履歴 / 2回上限 (issue #1, #2)
+
+- 各診断 (才覚領域 / MATRIX) は **最大 2 回** 実施できる。3 回目以降は API が 429 (`LIMIT_EXCEEDED`) を返す
+- SelectScreen に「診断済み (n/2)」バッジと「履歴を見る (n)」リンクが表示される
+- 履歴は `results/{uid}/attempts/{aid}` (才覚領域) と `uaam_results/{uid}/attempts/{aid}` (MATRIX) サブコレクションに保存
+- 詳細は [docs/design-rationale.md](./docs/design-rationale.md)
+
+---
+
+## 9. ローカル開発・テスト
+
+```bash
+# 全部同時起動 (emulator + API + Vite)
+npm run dev:local
+
+# 個別
+npm run emu       # Firebase emulator (auth:9099, firestore:8080, UI:4000)
+npm run api       # API server (localhost:3001)
+npm run dev       # Vite dev server (localhost:5173)
+```
+
+Vite が emulator に繋がる: `.env.local` に `VITE_USE_FIREBASE_EMULATOR=true`
+
+```bash
+# テスト
+npm run test:unit   # SelectScreen / attemptAdapter (10 テスト)
+npm run test:rules  # Firestore rules (20 テスト)
+npm run test:api    # Reservation Tx 統合 (12 テスト)
+npm run test:e2e    # Playwright (3 フロー)
+npm run test:all    # 全部
+```
+
+詳細: [docs/testing.md](./docs/testing.md)
+
+---
+
 ## アーキテクチャ図
 
 ```

--- a/api/_app.js
+++ b/api/_app.js
@@ -1,0 +1,52 @@
+/**
+ * ローカル開発・テスト用APIアプリ
+ * Vercelサーバーレス関数をExpressハンドラとして読み込む
+ */
+import dotenv from 'dotenv';
+dotenv.config({ path: '.env.local' });
+dotenv.config();
+
+import express from 'express';
+
+const app = express();
+app.use(express.json({ limit: '10mb' }));
+
+const analyzeHandler = await import('./analyze.js');
+const uaamHandler = await import('./uaam.js');
+
+let adminHandlers = {};
+try {
+  const fs = await import('fs');
+  const path = await import('path');
+  const adminDir = path.resolve('./api/admin');
+  if (fs.existsSync(adminDir)) {
+    const files = fs.readdirSync(adminDir).filter((f) => f.endsWith('.js'));
+    for (const file of files) {
+      const name = file.replace('.js', '');
+      const mod = await import(`./admin/${file}`);
+      adminHandlers[name] = mod.default || mod;
+    }
+  }
+} catch (e) {
+  console.log('⚠ admin handlers not loaded:', e.message);
+}
+
+app.get('/api/health', (_req, res) => {
+  res.json({ ok: true, mode: process.env.MOCK_ANTHROPIC === '1' ? 'mock' : 'live' });
+});
+
+app.all('/api/analyze', (req, res) => {
+  const handler = analyzeHandler.default || analyzeHandler;
+  return handler(req, res);
+});
+
+app.all('/api/uaam', (req, res) => {
+  const handler = uaamHandler.default || uaamHandler;
+  return handler(req, res);
+});
+
+for (const [name, handler] of Object.entries(adminHandlers)) {
+  app.all(`/api/admin/${name}`, (req, res) => handler(req, res));
+}
+
+export default app;

--- a/api/analyze.js
+++ b/api/analyze.js
@@ -239,7 +239,16 @@ export default async function handler(req, res) {
   // 認証
   let decoded;
   try {
-    decoded = await getAuth().verifyIdToken(idToken);
+    if (process.env.TEST_BYPASS_AUTH === '1') {
+      decoded = {
+        uid: req.headers['x-test-uid'] || 'test-user',
+        email: 'test@example.com',
+        name: 'Test',
+        picture: '',
+      };
+    } else {
+      decoded = await getAuth().verifyIdToken(idToken);
+    }
   } catch {
     return res.status(401).json({ error: '認証に失敗しました。再度ログインしてください。' });
   }

--- a/api/analyze.js
+++ b/api/analyze.js
@@ -239,7 +239,11 @@ export default async function handler(req, res) {
   // 認証
   let decoded;
   try {
-    if (process.env.TEST_BYPASS_AUTH === '1') {
+    if (
+      process.env.TEST_BYPASS_AUTH === '1'
+      && process.env.NODE_ENV === 'test'
+      && !!process.env.FIRESTORE_EMULATOR_HOST
+    ) {
       decoded = {
         uid: req.headers['x-test-uid'] || 'test-user',
         email: 'test@example.com',

--- a/api/analyze.js
+++ b/api/analyze.js
@@ -1,9 +1,12 @@
-import Anthropic from '@anthropic-ai/sdk';
 import { getAuth } from 'firebase-admin/auth';
-import { FieldValue } from 'firebase-admin/firestore';
-import { db } from './lib/firebaseAdmin.js';
-
-const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+import {
+  ConflictError,
+  LimitExceededError,
+  commitAttempt,
+  reserveAttempt,
+  rollbackAttempt,
+} from './lib/attempts.js';
+import { createMessage } from './lib/anthropicClient.js';
 
 const SYSTEM_PROMPT = `あなたは才覚領域アーキテクチャの専門分析AIです。
 ユーザーの才能・価値観・情熱から、その人だけの才覚領域を導き出します。
@@ -297,74 +300,124 @@ export default async function handler(req, res) {
     userMsg = `名前：${name || 'あなた'}\n才能：${talentLegacy}\n価値観：${valueLegacy}\n情熱：${passionLegacy}`;
   }
 
-  let result = null;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      const message = await client.messages.create({
-        model: 'claude-sonnet-4-20250514',
-        max_tokens: 8192,
-        system: SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: userMsg }],
-      });
-      const text = message.content[0].text;
-      const match =
-        text.match(/```json\n?([\s\S]*?)\n?```/) ||
-        text.match(/```\n?([\s\S]*?)\n?```/) ||
-        text.match(/(\{[\s\S]*\})/);
-      const jsonStr = match ? match[1] || match[0] : text;
-      const parsed = JSON.parse(jsonStr.trim());
-
-      // 必須フィールドの確認
-      if (!parsed.talent || !parsed.value || !parsed.passion || !parsed.kakuchiiki) {
-        throw new Error('APIレスポンスが不完全です');
-      }
-      // kakuchiiki_options がなければ kakuchiiki から生成
-      if (!parsed.kakuchiiki_options || !Array.isArray(parsed.kakuchiiki_options)) {
-        parsed.kakuchiiki_options = [parsed.kakuchiiki];
-      }
-
-      result = parsed;
-      break;
-    } catch (e) {
-      if (attempt === 2)
-        return res.status(500).json({ error: '解析に失敗しました。もう一度お試しください。' });
-      await new Promise((r) => setTimeout(r, 1000));
+  let attemptId;
+  try {
+    ({ attemptId } = await reserveAttempt({
+      collection: 'results',
+      uid: decoded.uid,
+      kind: 'saikaku',
+    }));
+  } catch (e) {
+    if (e instanceof LimitExceededError) {
+      return res.status(429).json({ error: e.message, code: 'LIMIT_EXCEEDED' });
     }
+    if (e instanceof ConflictError) {
+      return res.status(409).json({ error: e.message, code: 'PENDING_CONFLICT' });
+    }
+    throw e;
   }
 
-  const docRef = db.collection('results').doc(decoded.uid);
+  let result = null;
+  try {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const message = await createMessage({
+          fixtureKey: 'saikaku',
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 8192,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: 'user', content: userMsg }],
+        });
+        const text = message.content[0].text;
+        const match =
+          text.match(/```json\n?([\s\S]*?)\n?```/) ||
+          text.match(/```\n?([\s\S]*?)\n?```/) ||
+          text.match(/(\{[\s\S]*\})/);
+        const jsonStr = match ? match[1] || match[0] : text;
+        const parsed = JSON.parse(jsonStr.trim());
 
-  // 既存ドキュメントを確認（createdAt/consentAt は初回のみセット）
-  const existingDoc = await docRef.get();
-  const existing = existingDoc.data() || {};
+        // 必須フィールドの確認
+        if (!parsed.talent || !parsed.value || !parsed.passion || !parsed.kakuchiiki) {
+          throw new Error('APIレスポンスが不完全です');
+        }
+        // kakuchiiki_options がなければ kakuchiiki から生成
+        if (!parsed.kakuchiiki_options || !Array.isArray(parsed.kakuchiiki_options)) {
+          parsed.kakuchiiki_options = [parsed.kakuchiiki];
+        }
 
-  await docRef.set(
-    {
+        result = parsed;
+        break;
+      } catch (e) {
+        if (attempt === 2) throw e;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+  } catch (e) {
+    try {
+      await rollbackAttempt({ collection: 'results', uid: decoded.uid, attemptId });
+    } catch (rollbackError) {
+      console.error('[analyze] rollback failed:', rollbackError.message || rollbackError);
+    }
+    return res.status(500).json({ error: '解析に失敗しました。もう一度お試しください。' });
+  }
+
+  const selected = selectedKakuchiiki || result.kakuchiiki;
+  const rawInput = {
+    talent: talent_top5 || talentLegacy || '',
+    value: value_top5 || valueLegacy || '',
+    passion: passion_top5 || passionLegacy || '',
+    talentTop5: talent_top5 || '',
+    talentOther: talent_other || '',
+    valueTop5: value_top5 || '',
+    valueOther: value_other || '',
+    passionTop5: passion_top5 || '',
+    passionOther: passion_other || '',
+    q1: q1 || '',
+    q2: q2 || '',
+    q3: q3 || '',
+  };
+
+  try {
+    await commitAttempt({
+      collection: 'results',
       uid: decoded.uid,
-      name: name || decoded.name || '',
-      email: decoded.email || '',
-      photoURL: decoded.picture || '',
-      // 新フォーマットで保存（旧フィールドは後方互換のため維持）
-      inputTalent:  talent_top5  || talentLegacy  || '',
-      inputValue:   value_top5   || valueLegacy   || '',
-      inputPassion: passion_top5 || passionLegacy || '',
-      inputTalentTop5:   talent_top5  || '',
-      inputTalentOther:  talent_other || '',
-      inputValueTop5:    value_top5   || '',
-      inputValueOther:   value_other  || '',
-      inputPassionTop5:  passion_top5  || '',
-      inputPassionOther: passion_other || '',
-      inputQ1: q1 || '',
-      inputQ2: q2 || '',
-      inputQ3: q3 || '',
-      result,
-      selectedKakuchiiki: selectedKakuchiiki || result.kakuchiiki,
-      updatedAt: FieldValue.serverTimestamp(),
-      ...(!existing.createdAt ? { createdAt: FieldValue.serverTimestamp() } : {}),
-      ...(!existing.consentAt ? { consentAt: FieldValue.serverTimestamp() } : {}),
-    },
-    { merge: true }
-  );
+      attemptId,
+      summary: { kakuchiiki: result.kakuchiiki, typeName: null, createdAt: null },
+      full: { result, analysis: null, scores: null, selectedKakuchiiki: selected },
+      raw: { input: rawInput },
+      parentMerge: {
+        uid: decoded.uid,
+        name: name || decoded.name || '',
+        email: decoded.email || '',
+        photoURL: decoded.picture || '',
+        // 新フォーマットで保存（旧フィールドは後方互換のため維持）
+        inputTalent: rawInput.talent,
+        inputValue: rawInput.value,
+        inputPassion: rawInput.passion,
+        inputTalentTop5: rawInput.talentTop5,
+        inputTalentOther: rawInput.talentOther,
+        inputValueTop5: rawInput.valueTop5,
+        inputValueOther: rawInput.valueOther,
+        inputPassionTop5: rawInput.passionTop5,
+        inputPassionOther: rawInput.passionOther,
+        inputQ1: rawInput.q1,
+        inputQ2: rawInput.q2,
+        inputQ3: rawInput.q3,
+        result,
+        selectedKakuchiiki: selected,
+      },
+    });
+  } catch (e) {
+    try {
+      await rollbackAttempt({ collection: 'results', uid: decoded.uid, attemptId });
+    } catch (rollbackError) {
+      console.error('[analyze] rollback failed:', rollbackError.message || rollbackError);
+    }
+    if (e instanceof ConflictError) {
+      return res.status(409).json({ error: e.message, code: 'PENDING_CONFLICT' });
+    }
+    throw e;
+  }
 
   res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
   return res.status(200).json(result);

--- a/api/lib/anthropicClient.js
+++ b/api/lib/anthropicClient.js
@@ -35,6 +35,8 @@ export async function createMessage({ fixtureKey, ...params }) {
       throw new Error('mock LLM failure');
     }
     callCounter[fixtureKey] = (callCounter[fixtureKey] ?? 0) + 1;
+    const delay = Number(process.env.MOCK_ANTHROPIC_DELAY_MS || 0);
+    if (delay > 0) await new Promise((r) => setTimeout(r, delay));
     const file = fixtureKey === 'uaam' ? 'uaam-1.json' : 'saikaku-1.json';
     return loadFixture(file);
   }

--- a/api/lib/anthropicClient.js
+++ b/api/lib/anthropicClient.js
@@ -1,0 +1,42 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const isMock = process.env.MOCK_ANTHROPIC === '1';
+
+let realClient = null;
+function getReal() {
+  if (!realClient) realClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return realClient;
+}
+
+function loadFixture(name) {
+  const p = resolve(process.cwd(), 'tests/fixtures/anthropic', name);
+  const raw = readFileSync(p, 'utf-8');
+  return {
+    content: [{ type: 'text', text: raw }],
+  };
+}
+
+const callCounter = { saikaku: 0, uaam: 0 };
+
+export function getMockCallCount(key) {
+  return callCounter[key] ?? 0;
+}
+
+export function resetMockCallCount() {
+  callCounter.saikaku = 0;
+  callCounter.uaam = 0;
+}
+
+export async function createMessage({ fixtureKey, ...params }) {
+  if (isMock) {
+    callCounter[fixtureKey] = (callCounter[fixtureKey] ?? 0) + 1;
+    const file = fixtureKey === 'uaam' ? 'uaam-1.json' : 'saikaku-1.json';
+    return loadFixture(file);
+  }
+
+  return getReal().messages.create(params);
+}
+
+export const isMockMode = () => isMock;

--- a/api/lib/anthropicClient.js
+++ b/api/lib/anthropicClient.js
@@ -31,6 +31,9 @@ export function resetMockCallCount() {
 
 export async function createMessage({ fixtureKey, ...params }) {
   if (isMock) {
+    if (process.env.MOCK_ANTHROPIC_FAIL === '1') {
+      throw new Error('mock LLM failure');
+    }
     callCounter[fixtureKey] = (callCounter[fixtureKey] ?? 0) + 1;
     const file = fixtureKey === 'uaam' ? 'uaam-1.json' : 'saikaku-1.json';
     return loadFixture(file);

--- a/api/lib/attempts.js
+++ b/api/lib/attempts.js
@@ -1,0 +1,192 @@
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './firebaseAdmin.js';
+
+export class LimitExceededError extends Error {
+  constructor(message = '診断は最大2回までです') {
+    super(message);
+    this.name = 'LimitExceededError';
+    this.status = 429;
+  }
+}
+
+export class ConflictError extends Error {
+  constructor(message = '処理中のリクエストがあります') {
+    super(message);
+    this.name = 'ConflictError';
+    this.status = 409;
+  }
+}
+
+export async function reserveAttempt({ collection, uid, kind }) {
+  const docRef = db.collection(collection).doc(uid);
+
+  return await db.runTransaction(async (tx) => {
+    const cur = await tx.get(docRef);
+    const data = cur.exists ? cur.data() : {};
+
+    if (data.pendingAttemptId) {
+      throw new ConflictError('処理中のリクエストがあります');
+    }
+
+    let count = data.attemptCount ?? 0;
+
+    if (count === 0 && (data.result || data.analysis)) {
+      const legacyRef = docRef.collection('attempts').doc('legacy-v1');
+      const legacySnap = await tx.get(legacyRef);
+      if (!legacySnap.exists) {
+        tx.set(legacyRef, {
+          summary: extractSummary(data, kind),
+          full: extractFull(data, kind),
+          raw: extractRaw(data, kind),
+          status: 'committed',
+          isLegacy: true,
+          createdAt: data.createdAt ?? FieldValue.serverTimestamp(),
+        });
+      }
+      count = 1;
+    }
+
+    if (count >= 2) {
+      throw new LimitExceededError('診断は最大2回までです');
+    }
+
+    const newAttemptRef = docRef.collection('attempts').doc();
+    tx.set(newAttemptRef, {
+      status: 'pending',
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+    tx.set(
+      docRef,
+      {
+        attemptCount: count + 1,
+        pendingAttemptId: newAttemptRef.id,
+        updatedAt: FieldValue.serverTimestamp(),
+        ...(!data.createdAt ? { createdAt: FieldValue.serverTimestamp() } : {}),
+      },
+      { merge: true }
+    );
+
+    return { attemptId: newAttemptRef.id };
+  });
+}
+
+export async function commitAttempt({ collection, uid, attemptId, summary, full, raw, parentMerge }) {
+  const docRef = db.collection(collection).doc(uid);
+  const attemptRef = docRef.collection('attempts').doc(attemptId);
+
+  await db.runTransaction(async (tx) => {
+    const cur = await tx.get(docRef);
+    const data = cur.exists ? cur.data() : {};
+
+    if (data.pendingAttemptId !== attemptId) {
+      throw new ConflictError('reservation mismatch');
+    }
+
+    tx.set(
+      attemptRef,
+      {
+        summary,
+        full,
+        raw,
+        status: 'committed',
+      },
+      { merge: true }
+    );
+
+    tx.set(
+      docRef,
+      {
+        ...parentMerge,
+        pendingAttemptId: null,
+        latestAttemptId: attemptId,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+  });
+}
+
+export async function rollbackAttempt({ collection, uid, attemptId }) {
+  const docRef = db.collection(collection).doc(uid);
+  const attemptRef = docRef.collection('attempts').doc(attemptId);
+
+  await db.runTransaction(async (tx) => {
+    const cur = await tx.get(docRef);
+    const data = cur.exists ? cur.data() : {};
+
+    if (data.pendingAttemptId !== attemptId) {
+      return;
+    }
+
+    tx.delete(attemptRef);
+    tx.set(
+      docRef,
+      {
+        attemptCount: FieldValue.increment(-1),
+        pendingAttemptId: null,
+      },
+      { merge: true }
+    );
+  });
+}
+
+function extractSummary(data, kind) {
+  if (kind === 'saikaku') {
+    return {
+      kakuchiiki: data?.result?.kakuchiiki ?? data?.selectedKakuchiiki ?? null,
+      typeName: null,
+      createdAt: data?.createdAt ?? null,
+    };
+  }
+
+  return {
+    typeName: data?.analysis?.type_name ?? null,
+    createdAt: data?.createdAt ?? null,
+  };
+}
+
+function extractFull(data, kind) {
+  if (kind === 'saikaku') {
+    return {
+      result: data?.result ?? null,
+      analysis: null,
+      scores: null,
+      selectedKakuchiiki: data?.selectedKakuchiiki ?? null,
+    };
+  }
+
+  return {
+    result: null,
+    analysis: data?.analysis ?? null,
+    scores: data?.scores ?? null,
+  };
+}
+
+function extractRaw(data, kind) {
+  if (kind === 'saikaku') {
+    return {
+      input: {
+        talent: data?.inputTalent ?? '',
+        value: data?.inputValue ?? '',
+        passion: data?.inputPassion ?? '',
+        talentTop5: data?.inputTalentTop5 ?? '',
+        talentOther: data?.inputTalentOther ?? '',
+        valueTop5: data?.inputValueTop5 ?? '',
+        valueOther: data?.inputValueOther ?? '',
+        passionTop5: data?.inputPassionTop5 ?? '',
+        passionOther: data?.inputPassionOther ?? '',
+        q1: data?.inputQ1 ?? '',
+        q2: data?.inputQ2 ?? '',
+        q3: data?.inputQ3 ?? '',
+      },
+    };
+  }
+
+  return {
+    input: {
+      answers: data?.answers ?? null,
+      vAnswers: data?.vAnswers ?? null,
+    },
+  };
+}

--- a/api/lib/attempts.js
+++ b/api/lib/attempts.js
@@ -17,14 +17,18 @@ export class ConflictError extends Error {
   }
 }
 
+const RESERVATION_LOCK_ID = 'reservation';
+
 export async function reserveAttempt({ collection, uid, kind }) {
   const docRef = db.collection(collection).doc(uid);
+  const lockRef = docRef.collection('_locks').doc(RESERVATION_LOCK_ID);
 
   return await db.runTransaction(async (tx) => {
     const cur = await tx.get(docRef);
+    const lockSnap = await tx.get(lockRef);
     const data = cur.exists ? cur.data() : {};
 
-    if (data.pendingAttemptId) {
+    if (lockSnap.exists || data.pendingAttemptId) {
       throw new ConflictError('処理中のリクエストがあります');
     }
 
@@ -51,11 +55,14 @@ export async function reserveAttempt({ collection, uid, kind }) {
     }
 
     const newAttemptRef = docRef.collection('attempts').doc();
+    tx.create(lockRef, {
+      attemptId: newAttemptRef.id,
+      acquiredAt: FieldValue.serverTimestamp(),
+    });
     tx.set(newAttemptRef, {
       status: 'pending',
       createdAt: FieldValue.serverTimestamp(),
     });
-
     tx.set(
       docRef,
       {
@@ -74,6 +81,7 @@ export async function reserveAttempt({ collection, uid, kind }) {
 export async function commitAttempt({ collection, uid, attemptId, summary, full, raw, parentMerge }) {
   const docRef = db.collection(collection).doc(uid);
   const attemptRef = docRef.collection('attempts').doc(attemptId);
+  const lockRef = docRef.collection('_locks').doc(RESERVATION_LOCK_ID);
 
   await db.runTransaction(async (tx) => {
     const cur = await tx.get(docRef);
@@ -104,12 +112,14 @@ export async function commitAttempt({ collection, uid, attemptId, summary, full,
       },
       { merge: true }
     );
+    tx.delete(lockRef);
   });
 }
 
 export async function rollbackAttempt({ collection, uid, attemptId }) {
   const docRef = db.collection(collection).doc(uid);
   const attemptRef = docRef.collection('attempts').doc(attemptId);
+  const lockRef = docRef.collection('_locks').doc(RESERVATION_LOCK_ID);
 
   await db.runTransaction(async (tx) => {
     const cur = await tx.get(docRef);
@@ -120,6 +130,7 @@ export async function rollbackAttempt({ collection, uid, attemptId }) {
     }
 
     tx.delete(attemptRef);
+    tx.delete(lockRef);
     tx.set(
       docRef,
       {

--- a/api/lib/attempts.js
+++ b/api/lib/attempts.js
@@ -18,6 +18,17 @@ export class ConflictError extends Error {
 }
 
 const RESERVATION_LOCK_ID = 'reservation';
+const RESERVATION_LOCK_TTL_MS = 10 * 60 * 1000;
+
+function lockExpired(lockData) {
+  const acquiredAt = lockData?.acquiredAt;
+  if (!acquiredAt) return false;
+  const acquiredMs = typeof acquiredAt.toMillis === 'function'
+    ? acquiredAt.toMillis()
+    : new Date(acquiredAt).getTime();
+  if (!Number.isFinite(acquiredMs)) return false;
+  return Date.now() - acquiredMs > RESERVATION_LOCK_TTL_MS;
+}
 
 export async function reserveAttempt({ collection, uid, kind }) {
   const docRef = db.collection(collection).doc(uid);
@@ -28,7 +39,8 @@ export async function reserveAttempt({ collection, uid, kind }) {
     const lockSnap = await tx.get(lockRef);
     const data = cur.exists ? cur.data() : {};
 
-    if (lockSnap.exists || data.pendingAttemptId) {
+    const lockHeld = lockSnap.exists && !lockExpired(lockSnap.data());
+    if (lockHeld || data.pendingAttemptId) {
       throw new ConflictError('処理中のリクエストがあります');
     }
 
@@ -55,10 +67,15 @@ export async function reserveAttempt({ collection, uid, kind }) {
     }
 
     const newAttemptRef = docRef.collection('attempts').doc();
-    tx.create(lockRef, {
+    const lockData = {
       attemptId: newAttemptRef.id,
       acquiredAt: FieldValue.serverTimestamp(),
-    });
+    };
+    if (lockSnap.exists) {
+      tx.set(lockRef, lockData);
+    } else {
+      tx.create(lockRef, lockData);
+    }
     tx.set(newAttemptRef, {
       status: 'pending',
       createdAt: FieldValue.serverTimestamp(),

--- a/api/lib/firebaseAdmin.js
+++ b/api/lib/firebaseAdmin.js
@@ -1,14 +1,21 @@
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
+const isEmulator = !!process.env.FIRESTORE_EMULATOR_HOST;
+
 if (!getApps().length) {
-  initializeApp({
-    credential: cert({
-      projectId: process.env.FIREBASE_PROJECT_ID,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-    }),
-  });
+  if (isEmulator) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+    console.log('[firebase-admin] emulator mode: firestore=', process.env.FIRESTORE_EMULATOR_HOST, 'auth=', process.env.FIREBASE_AUTH_EMULATOR_HOST);
+  } else {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      }),
+    });
+  }
 }
 
 export const db = getFirestore();

--- a/api/uaam.js
+++ b/api/uaam.js
@@ -201,7 +201,11 @@ export default async function handler(req, res) {
   // 認証
   let decoded;
   try {
-    if (process.env.TEST_BYPASS_AUTH === '1') {
+    if (
+      process.env.TEST_BYPASS_AUTH === '1'
+      && process.env.NODE_ENV === 'test'
+      && !!process.env.FIRESTORE_EMULATOR_HOST
+    ) {
       decoded = {
         uid: req.headers['x-test-uid'] || 'test-user',
         email: 'test@example.com',

--- a/api/uaam.js
+++ b/api/uaam.js
@@ -201,7 +201,16 @@ export default async function handler(req, res) {
   // 認証
   let decoded;
   try {
-    decoded = await getAuth().verifyIdToken(idToken);
+    if (process.env.TEST_BYPASS_AUTH === '1') {
+      decoded = {
+        uid: req.headers['x-test-uid'] || 'test-user',
+        email: 'test@example.com',
+        name: 'Test',
+        picture: '',
+      };
+    } else {
+      decoded = await getAuth().verifyIdToken(idToken);
+    }
   } catch {
     return res.status(401).json({ error: '認証に失敗しました。再度ログインしてください。' });
   }

--- a/api/uaam.js
+++ b/api/uaam.js
@@ -1,9 +1,13 @@
-import Anthropic from '@anthropic-ai/sdk';
 import { getAuth } from 'firebase-admin/auth';
-import { FieldValue } from 'firebase-admin/firestore';
 import { db } from './lib/firebaseAdmin.js';
-
-const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+import {
+  ConflictError,
+  LimitExceededError,
+  commitAttempt,
+  reserveAttempt,
+  rollbackAttempt,
+} from './lib/attempts.js';
+import { createMessage } from './lib/anthropicClient.js';
 
 /**
  * スコア計算（サーバーサイド）
@@ -224,6 +228,23 @@ export default async function handler(req, res) {
   // スコア計算
   const scores = calculateScores(answers, QUESTIONS);
 
+  let attemptId;
+  try {
+    ({ attemptId } = await reserveAttempt({
+      collection: 'uaam_results',
+      uid: decoded.uid,
+      kind: 'uaam',
+    }));
+  } catch (e) {
+    if (e instanceof LimitExceededError) {
+      return res.status(429).json({ error: e.message, code: 'LIMIT_EXCEEDED' });
+    }
+    if (e instanceof ConflictError) {
+      return res.status(409).json({ error: e.message, code: 'PENDING_CONFLICT' });
+    }
+    throw e;
+  }
+
   // 才覚領域データを取得
   let saikakuData = null;
   try {
@@ -267,57 +288,76 @@ ${Object.entries(scores.competency.subs).map(([k, v]) => `  ${k}: ${v}/20`).join
 ${Object.entries(scores.impact.subs).map(([k, v]) => `  ${k}: ${v}/20`).join('\n')}`;
 
   let analysis = null;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      const message = await client.messages.create({
-        model: 'claude-sonnet-4-20250514',
-        max_tokens: 4096,
-        system: UAAM_SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: userMsg }],
-      });
-      const text = message.content[0].text;
-      const match =
-        text.match(/```json\n?([\s\S]*?)\n?```/) ||
-        text.match(/```\n?([\s\S]*?)\n?```/) ||
-        text.match(/(\{[\s\S]*\})/);
-      const jsonStr = match ? match[1] || match[0] : text;
-      const parsed = JSON.parse(jsonStr.trim());
+  try {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const message = await createMessage({
+          fixtureKey: 'uaam',
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 4096,
+          system: UAAM_SYSTEM_PROMPT,
+          messages: [{ role: 'user', content: userMsg }],
+        });
+        const text = message.content[0].text;
+        const match =
+          text.match(/```json\n?([\s\S]*?)\n?```/) ||
+          text.match(/```\n?([\s\S]*?)\n?```/) ||
+          text.match(/(\{[\s\S]*\})/);
+        const jsonStr = match ? match[1] || match[0] : text;
+        const parsed = JSON.parse(jsonStr.trim());
 
-      if (!parsed.type_name || !parsed.narrative) {
-        throw new Error('APIレスポンスが不完全です');
+        if (!parsed.type_name || !parsed.narrative) {
+          throw new Error('APIレスポンスが不完全です');
+        }
+
+        analysis = parsed;
+        break;
+      } catch (e) {
+        console.error(`[UAAM] attempt ${attempt + 1} failed:`, e.message || e);
+        if (e.status) console.error(`[UAAM] API status: ${e.status}`);
+        if (attempt === 2) throw e;
+        await new Promise((r) => setTimeout(r, 1000));
       }
-
-      analysis = parsed;
-      break;
-    } catch (e) {
-      console.error(`[UAAM] attempt ${attempt + 1} failed:`, e.message || e);
-      if (e.status) console.error(`[UAAM] API status: ${e.status}`);
-      if (attempt === 2)
-        return res.status(500).json({ error: `分析に失敗しました: ${e.message}` });
-      await new Promise((r) => setTimeout(r, 1000));
     }
+  } catch (e) {
+    try {
+      await rollbackAttempt({ collection: 'uaam_results', uid: decoded.uid, attemptId });
+    } catch (rollbackError) {
+      console.error('[UAAM] rollback failed:', rollbackError.message || rollbackError);
+    }
+    return res.status(500).json({ error: `分析に失敗しました: ${e.message}` });
   }
 
-  // Firestore保存
-  const docRef = db.collection('uaam_results').doc(decoded.uid);
-  const existingDoc = await docRef.get();
-  const existing = existingDoc.data() || {};
-
-  await docRef.set(
-    {
+  try {
+    await commitAttempt({
+      collection: 'uaam_results',
       uid: decoded.uid,
-      name: decoded.name || '',
-      email: decoded.email || '',
-      photoURL: decoded.picture || '',
-      answers,
-      vAnswers: vAnswers || {},
-      scores,
-      analysis,
-      updatedAt: FieldValue.serverTimestamp(),
-      ...(!existing.createdAt ? { createdAt: FieldValue.serverTimestamp() } : {}),
-    },
-    { merge: true }
-  );
+      attemptId,
+      summary: { typeName: analysis.type_name, createdAt: null },
+      full: { result: null, analysis, scores },
+      raw: { input: { answers, vAnswers: vAnswers || {} } },
+      parentMerge: {
+        uid: decoded.uid,
+        name: decoded.name || '',
+        email: decoded.email || '',
+        photoURL: decoded.picture || '',
+        answers,
+        vAnswers: vAnswers || {},
+        scores,
+        analysis,
+      },
+    });
+  } catch (e) {
+    try {
+      await rollbackAttempt({ collection: 'uaam_results', uid: decoded.uid, attemptId });
+    } catch (rollbackError) {
+      console.error('[UAAM] rollback failed:', rollbackError.message || rollbackError);
+    }
+    if (e instanceof ConflictError) {
+      return res.status(409).json({ error: e.message, code: 'PENDING_CONFLICT' });
+    }
+    throw e;
+  }
 
   res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
   return res.status(200).json({ scores, analysis });

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -1,0 +1,124 @@
+# 設計判断の根拠 (Design Rationale)
+
+> このドキュメントは「なぜこうしたか」を記録する。コード/SETUP は「何をしたか」「どう動かすか」だけ書く。
+> 元 Issue: #1 (診断済みバッジ), #2 (履歴 + 2回上限)
+> 確定: 2026-05-02
+
+---
+
+## 1. データモデル: サブコレクション + 親doc サマリ + Read-Time Fallback
+
+### 採用案
+```
+results/{uid}                       // 親doc
+  attemptCount: 0 | 1 | 2
+  pendingAttemptId: string | null   // 予約中のattemptId
+  latestAttemptId: string | null
+  result: {...}                     // 既存後方互換用サマリ
+  selectedKakuchiiki, consentAt, createdAt, updatedAt
+  attempts/{aid}                    // サブコレクション (Admin SDK のみ書込)
+    summary: { kakuchiiki?, typeName?, createdAt }
+    full:    { result?, analysis?, scores?, selectedKakuchiiki? }
+    raw:     { input: {...} }
+    status:  'pending' | 'committed'
+    isLegacy?: boolean
+  _locks/reservation                // Reservation Transaction 用ロック
+    attemptId, acquiredAt
+```
+uaam_results も同構造。
+
+### なぜこうしたか
+- **サブコレクション**: 1 attempt が summary+full+raw で 200KB になる可能性があるため、Firestore の 1 MiB doc 上限を 1 attempt 単位で消費しない構造にした。1 attempt が肥大化したら `attempts/{aid}/raw/0` のように更に分離可能 (将来オプション)
+- **summary/full/raw の分離**: 一覧 (HistoryScreen) では summary だけ読めば良く、詳細遷移時のみ full を解決する設計余地を残す。今回の MVP では HistoryScreen も attempt 全体を読んでいるが、件数が増えた時に summary だけ取る最適化が可能
+- **親doc に `result` を残す (後方互換)**: `api/integrate.js` 等の既存 admin 系 API が `result` を直接読んでいる。サブコレクションへの完全移行は破壊的変更になるため、commit 時に親docの `result` も同期更新して両対応
+- **Read-Time Fallback**: legacy ユーザー (attempts サブコレ未作成 + 親docに result/analysis あり) で履歴画面が空にならないよう、`HistoryScreen` で attempts 空 + 親doc に result/analysis がある場合に親docを擬似 attempt として 1 件目に合成する (`legacyDocToAttempt`)。これにより遅延 migration でも履歴が即時表示される
+
+### なぜ別案を採らなかったか
+- **単一 doc に attempts 配列を埋め込む**: doc 上限 1 MiB と部分更新が難しい (配列要素単位の atomic update が Firestore では制約あり)
+- **完全フラット (results/{uid}/{attempt-1}) で attempts と diagnostic 結果を分離**: 既存 query パターンとの互換性が崩れ、admin 画面の改修コストが大きい
+
+---
+
+## 2. 並行リクエスト保護: Reservation Transaction + Pending Lock
+
+### 問題
+LLM (Anthropic API) は 5-30 秒かかる高コスト呼び出し。ユーザーが連打した場合や、ネットワーク遅延でクライアントがリトライした場合に、同一 UID で複数の LLM 呼び出しが並列発火するとコストが膨らむ。最大 2 回上限の判定もこの並行性下で正確に動かなければならない。
+
+### 採用案
+```
+[Reserve Transaction]   ← LLM 呼び出し前に枠を予約
+        ↓ 成功
+[LLM 呼び出し]          ← Anthropic API
+        ↓ 成功
+[Commit Transaction]    ← attempt doc を pending → committed に書き換え
+        ↓ 失敗
+[Rollback Transaction]  ← attemptCount を1戻す + pending attempt を削除
+```
+
+ガード:
+- Reservation Tx 内で `_locks/reservation` を `tx.create` する。同時 2 リクエストで両方 reserve しようとすると、tx.create が write-write conflict を発生させる
+- 同時に `pendingAttemptId` を親docにセットすることで二重防御
+- TTL 10 分: 期限切れの lock は次の reserve で `tx.set` 上書き (LLM タイムアウト等で lock が残っても自動回復)
+
+### なぜこうしたか
+- **Pending Lock (`_locks/reservation`)**: Firestore Admin SDK transaction の OCC は production では正しく動くが、Firestore Emulator は write-write conflict 検出が緩い。テスト環境でも production と同じ挙動を担保するため、`tx.create` で「doc が存在したら必ず失敗」する仕組みを追加。これは pessimistic lock として機能する
+- **TTL 10 分**: Vercel serverless function の最大実行時間 (10 秒〜60 秒) より大幅に長く設定。 lock が永続残置するケースはサーバー死亡時のみ。10 分後に自動失効するので運用ブロックは発生しない
+- **deterministic legacy migration ID `legacy-v1`**: migration 処理が並列で走っても同じ ID で書くため、二重作成されない。`tx.get` で existence チェック → 存在しなければ書き込む冪等性を保証
+
+### なぜ別案を採らなかったか
+- **In-memory lock (Map[uid] = Promise)**: serverless 環境では各リクエストが別インスタンスで走るため、プロセス内ロックは効果なし
+- **Counter + transaction without lock**: emulator の OCC が緩く、テストで race を再現できない。production への自信が下がる
+
+---
+
+## 3. Firestore rules: 厳格な allow-list
+
+### 採用案
+- `results/{uid}`: `consentAt` (timestamp) と `selectedKakuchiiki` (string < 200 字) の **only** クライアント update 可
+- `attempts/*`: 全 write 禁止 (Admin SDK のみ)
+- `_locks/*`: read/write 完全禁止 (Admin SDK のみ)
+- `delete`: 親doc/サブコレクション全て禁止
+- `create`: `consentAt` のみ含む doc を本人 UID で作成のみ許可
+
+### なぜこうしたか
+- **fields allow-list with `affectedKeys().hasOnly([...])`**: 既存の `LoginScreen.jsx` (consentAt) と `ResultScreen.jsx:296` (selectedKakuchiiki) のみが直書きするフィールドなので、それ以外は API 経由のみ。攻撃者が devtools から `result` 等を改ざんできない
+- **type/size validation**: 攻撃者が巨大文字列で 1 MiB 制限を圧迫する DoS 防御。timestamp 型強制で型混在防止
+- **delete: false**: 履歴を恣意的に消されない監査保証
+
+---
+
+## 4. MATRIX (UAAM) パスワード方針: (a) 受験者制限
+
+### 採用案
+`UAAM_PASS = 'kokusogaku'` の意図は **「許可した人だけが MATRIX 診断を受けられる」受験者制限** と確定 (つかさ確認 2026-05-02)。
+
+- バッジ・履歴一覧・履歴詳細は **パス入力前から表示**
+- 「診断を開始する」ボタンクリック時のみ既存パスワードモーダル
+
+### なぜこうしたか
+- 結果プライバシー (家族・同居人に見られたくない) はこのパスワードの責務ではない。それは別レイヤー (端末ロック等) で対処
+- バッジ/履歴は「自分が過去にやったか」の事実情報で、再受験 (新規 LLM 呼び出し) ほど機密ではない
+- 受験のみゲートする方が UX が良い (既受験者が再ログインで履歴を見るたびにパス入力するのは面倒)
+
+### 既知の限界 (別 issue 化)
+- `UAAM_PASS` がフロント bundle に含まれるため、curl で `/api/uaam` を叩けば受験者制限はバイパス可能
+- 真の受験者制限が必要なら `ADMIN_EMAILS` allowlist or Firebase custom claims でサーバー側検証する別 issue
+
+---
+
+## 5. テスト戦略
+
+### 4 層構成
+- `tests/unit`: SelectScreen バッジ表示 + attemptAdapter のロジック
+- `tests/rules`: Firestore rules を `@firebase/rules-unit-testing` で 20 シナリオ検証
+- `tests/api`: `supertest(app)` で Reservation/Commit/Rollback/migration/concurrency を 12 シナリオ検証
+- `tests/e2e`: Playwright で 3 フロー (badge / history / limit)
+
+### LLM Mock を API server 側に
+- ブラウザ MSW では Node 側の Anthropic SDK 呼び出しを捕捉できない
+- `api/lib/anthropicClient.js` に MOCK_ANTHROPIC=1 wrapper を実装
+- fixture JSON (`tests/fixtures/anthropic/{saikaku,uaam}-1.json`) を返す
+- 副次機能: MOCK_ANTHROPIC_FAIL=1 で LLM 失敗を模擬 (rollback テスト用)、MOCK_ANTHROPIC_DELAY_MS で遅延注入 (concurrency テストで reserve→commit 窓を確保)
+
+### TEST_BYPASS_AUTH ガード
+本番混入を防ぐため三重ガード: `TEST_BYPASS_AUTH=1` AND `NODE_ENV=test` AND `FIRESTORE_EMULATOR_HOST` セット時のみ有効。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,101 @@
+# テスト実行ガイド
+
+## 4 層テスト
+
+| 層 | コマンド | カバレッジ | 所要時間 |
+|----|----------|------------|----------|
+| Unit | `npm run test:unit` | バッジ表示ロジック / attemptAdapter | < 1 秒 |
+| Rules | `npm run test:rules` | Firestore rules 20 シナリオ | 〜2 秒 |
+| API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency 12 シナリオ | 〜20 秒 |
+| E2E | `npm run test:e2e` | Playwright 3 フロー (badge/history/limit) | 〜60 秒 |
+| **All** | `npm run test:all` | 全部直列実行 | 〜90 秒 |
+
+## 前提
+
+- Node.js v22+
+- `npm install` 済み
+- emulator 用 JDK が `/opt/homebrew/opt/openjdk@21` にあること (test:rules / test:api / test:e2e で必要)
+- Playwright ブラウザ: `npx playwright install chromium` (test:e2e 初回のみ)
+
+## ローカル開発時の手動実行
+
+`firebase emulators:exec` を使わず、起動済みエミュレータに直接テストを当てたい場合:
+
+```bash
+# emulator を起動 (別ターミナル)
+npm run emu
+
+# rules テスト
+FIRESTORE_EMULATOR_HOST=localhost:8080 \
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099 \
+FIREBASE_PROJECT_ID=demo-saikaku \
+GCLOUD_PROJECT=demo-saikaku \
+NODE_ENV=test \
+npx vitest run tests/rules
+
+# API テスト
+FIRESTORE_EMULATOR_HOST=localhost:8080 \
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099 \
+FIREBASE_PROJECT_ID=demo-saikaku \
+GCLOUD_PROJECT=demo-saikaku \
+MOCK_ANTHROPIC=1 \
+TEST_BYPASS_AUTH=1 \
+NODE_ENV=test \
+npx vitest run tests/api
+```
+
+## LLM Mock の運用
+
+`api/lib/anthropicClient.js` の `createMessage()` は環境変数で挙動を切り替える:
+
+| 環境変数 | 値 | 効果 |
+|----------|----|------|
+| `MOCK_ANTHROPIC` | `1` | fixture JSON を返す (`tests/fixtures/anthropic/{saikaku,uaam}-1.json`) |
+| `MOCK_ANTHROPIC` | unset | 実際の Anthropic SDK 呼び出し |
+| `MOCK_ANTHROPIC_FAIL` | `1` | mock 中に必ず throw (rollback テスト用) |
+| `MOCK_ANTHROPIC_DELAY_MS` | `1500` | mock 応答を 1.5 秒遅らせる (concurrency テスト用) |
+
+`MOCK_ANTHROPIC_DELAY_MS` の用途:
+Reservation Tx 間で発生する race を再現するため、最初の reserve→commit 完了前に 2 つ目の reserve がエントリーする時間窓を確保する。production の実 LLM (5-30 秒) では自然に発生する race が、emulator + 即応 mock では再現しない。
+
+## E2E orchestrator (`scripts/test-e2e-orchestrator.mjs`)
+
+`npm run test:e2e` が起動するスクリプト。順序:
+1. ポート 3001 / 5173 / 8080 / 9099 が空いているか確認 (使用中なら abort)
+2. `firebase emulators:start --only auth,firestore --project demo-saikaku` を bg 起動
+3. `wait-on tcp:9099 tcp:8080` で ready 待ち
+4. `MOCK_ANTHROPIC=1 NODE_ENV=test TEST_BYPASS_AUTH=1 node server.js` を bg 起動
+5. `wait-on http://localhost:3001/api/health` で API ready 待ち
+6. `npm run dev -- --port 5173 --strictPort` (Vite) を bg 起動
+7. `wait-on http://localhost:5173` で Vite ready 待ち
+8. `npx playwright test` を実行 → 結果を exit code に伝搬
+9. SIGTERM で全 bg プロセス停止
+
+ローカル開発で emulator/Vite が常駐している場合は orchestrator を使わず直接 `npx playwright test` でも動く (環境変数を手動設定)。
+
+## TEST_BYPASS_AUTH のガード
+
+API テストでは Firebase Admin verifyIdToken をスキップするため `TEST_BYPASS_AUTH=1` を使うが、本番混入を防ぐ三重ガード:
+
+```js
+if (
+  process.env.TEST_BYPASS_AUTH === '1'
+  && process.env.NODE_ENV === 'test'
+  && !!process.env.FIRESTORE_EMULATOR_HOST
+) {
+  // bypass
+}
+```
+
+`tests/api/_helpers.js` は import 時にこの三条件を assert する。条件を満たさずに `npm run test:api` 以外で実行されると即時 throw する fail-fast 設計。
+
+## トラブルシュート
+
+### `port X is already in use`
+ローカルで他のプロセスが emulator/API/Vite ポートを使用中。`lsof -i :8080` で特定して停止するか、各テストスクリプトを emulator 起動済みの環境で個別に走らせる (上記の「手動実行」)。
+
+### `Could not start Firestore Emulator, port taken`
+`npm run test:rules` / `test:api` 内の `firebase emulators:exec` が新規 emulator を起動しようとして失敗。既に emulator が起動済みなら、上記の手動実行コマンドで対応。
+
+### concurrency テストが flaky
+`MOCK_ANTHROPIC_DELAY_MS` が小さすぎる可能性。`tests/api/concurrent-from-{zero,one}.test.js` で 1500ms に設定しているが、CI 環境が遅い場合は 2000ms 以上に上げる。

--- a/firebase.json
+++ b/firebase.json
@@ -2,5 +2,18 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "singleProjectMode": true
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -36,6 +36,10 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    match /results/{uid}/_locks/{lockId} {
+      allow read, write: if false;
+    }
+
     match /uaam_results/{uid} {
       allow read: if signedInAs(uid);
       allow write: if false;
@@ -44,6 +48,10 @@ service cloud.firestore {
     match /uaam_results/{uid}/attempts/{aid} {
       allow read: if signedInAs(uid);
       allow write: if false;
+    }
+
+    match /uaam_results/{uid}/_locks/{lockId} {
+      allow read, write: if false;
     }
 
     match /{document=**} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,19 +2,50 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // results コレクション：本人のみ読み書き可
-    // 管理者の読み取りは firebase-admin（バックエンド）経由のため
-    // フロントからの直接アクセスは本人分のみに制限する
+    // Client writes are restricted to consentAt and selectedKakuchiiki.
+    // All attempts/* writes go through the Admin SDK only.
+    // Diagnostic results and uaam_results are written exclusively by the API server.
+    function signedInAs(uid) {
+      return request.auth != null && request.auth.uid == uid;
+    }
+
+    function changedKeys() {
+      return request.resource.data.diff(resource.data).affectedKeys();
+    }
+
     match /results/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
+      allow read: if signedInAs(uid);
+
+      allow create: if signedInAs(uid)
+        && request.resource.data.keys().hasOnly(['consentAt'])
+        && request.resource.data.consentAt is timestamp;
+
+      allow update: if signedInAs(uid)
+        && changedKeys().hasOnly(['consentAt', 'selectedKakuchiiki'])
+        && (!changedKeys().hasAny(['consentAt'])
+             || request.resource.data.consentAt is timestamp)
+        && (!changedKeys().hasAny(['selectedKakuchiiki'])
+             || (request.resource.data.selectedKakuchiiki is string
+                 && request.resource.data.selectedKakuchiiki.size() < 200));
+
+      allow delete: if false;
     }
 
-    // uaam_results コレクション：本人のみ読み書き可
+    match /results/{uid}/attempts/{aid} {
+      allow read: if signedInAs(uid);
+      allow write: if false;
+    }
+
     match /uaam_results/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
+      allow read: if signedInAs(uid);
+      allow write: if false;
     }
 
-    // その他のコレクションへのアクセスはすべて拒否
+    match /uaam_results/{uid}/attempts/{aid} {
+      allow read: if signedInAs(uid);
+      allow write: if false;
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,10 @@
         "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.3",
         "autoprefixer": "^10.4.20",
+        "concurrently": "^9.2.1",
+        "dotenv": "^17.4.2",
+        "express": "^5.2.1",
+        "firebase-tools": "^15.15.0",
         "jsdom": "^29.0.2",
         "postcss": "^8.4.48",
         "tailwindcss": "^3.4.15",
@@ -80,6 +84,81 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apphosting/build": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@apphosting/build/-/build-0.1.7.tgz",
+      "integrity": "sha512-zNgQGiAWDOj6c+4ylv5ej3nLGXzMAVmzCGMqlbSarHe4bvBmZ2C5GfBRdJksedP7C9pqlwTWpxU5+GSzhJ+nKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apphosting/common": "^0.0.9",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "colorette": "^2.0.20",
+        "commander": "^11.1.0",
+        "npm-pick-manifest": "^9.0.0",
+        "ts-node": "^10.9.1"
+      },
+      "bin": {
+        "apphosting-local-build": "dist/bin/localbuild.js"
+      }
+    },
+    "node_modules/@apphosting/build/node_modules/@apphosting/common": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@apphosting/common/-/common-0.0.9.tgz",
+      "integrity": "sha512-ZbPZDcVhEN+8m0sf90PmQN4xWaKmmySnBSKKPaIOD0JvcDsRr509WenFEFlojP++VSxwFZDGG/TYsHs1FMMqpw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@apphosting/build/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@apphosting/common": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@apphosting/common/-/common-0.0.8.tgz",
+      "integrity": "sha512-RJu5gXs2HYV7+anxpVPpp04oXeuHbV3qn402AdXVlnuYM/uWo7aceqmngpfp6Bi376UzRqGjfpdwFHxuwsEGXQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -437,6 +516,41 @@
         "specificity": "bin/cli.js"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -577,6 +691,36 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
+      "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.21.tgz",
+      "integrity": "sha512-kv8Z7UmmBVECHud63VblgQLp4A+qSklNP7H22VQqFQGrWFTodc73bubcjgmBqThFsIIiEeAEQQYwWGaK2lSDtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.16"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1623,6 +1767,109 @@
       "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@google-cloud/cloud-sql-connector": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/cloud-sql-connector/-/cloud-sql-connector-1.10.0.tgz",
+      "integrity": "sha512-PLix9OUaeAfVOKFAqw32/ETvFPef26mcTmDu/iVShGRs+MB1JkL98SwVLHsEjzjfnZrF+BtKqnseoFw0+3LmPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@googleapis/sqladmin": "^35.2.0",
+        "gaxios": "^7.1.4",
+        "google-auth-library": "^10.6.2",
+        "p-throttle": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
@@ -1654,6 +1901,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.0.0.tgz",
+      "integrity": "sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/projectify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
@@ -1672,6 +1929,266 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/pubsub": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-5.3.0.tgz",
+      "integrity": "sha512-hyUoE85Rj3rRUVk3VU+Selp4MorBwEzsQEqAj6+SE+WabR9LIFitYS6A4R+PyiwVaRk/tggGD8p7bNiIY5sk4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^6.0.0",
+        "@google-cloud/precise-date": "^5.0.0",
+        "@google-cloud/projectify": "^5.0.0",
+        "@google-cloud/promisify": "^5.0.0",
+        "@opentelemetry/api": "~1.9.0",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "~1.39.0",
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^10.5.0",
+        "google-gax": "^5.0.5",
+        "heap-js": "^2.6.0",
+        "is-stream-ended": "^0.1.4",
+        "lodash.snakecase": "^4.1.1",
+        "p-defer": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@google-cloud/paginator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
+      "integrity": "sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@google-cloud/projectify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-5.0.0.tgz",
+      "integrity": "sha512-XXQLaIcLrOAMWvRrzz+mlUGtN6vlVNja3XQbMqRi/V7XJTAVwib3VcKd7oRwyZPkp7rBVlHGcaqdyGRrcnkhlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@google-cloud/promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.0.tgz",
+      "integrity": "sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-gax": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.6.tgz",
+      "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^10.1.0",
+        "google-logging-utils": "^1.1.1",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^3.0.0",
+        "protobufjs": "^7.5.3",
+        "retry-request": "^8.0.0",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/teeny-request": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/storage": {
@@ -1711,6 +2228,19 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@googleapis/sqladmin": {
+      "version": "35.2.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sqladmin/-/sqladmin-35.2.0.tgz",
+      "integrity": "sha512-ajR9EGLs1pCkKfsXxfbVRnQ7ZPyktKNAuahHoU06CVKguWwQo3b9aFmq06PYnGk1oXc0+tlW+XEamNa/HF4pbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
@@ -1740,6 +2270,500 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1796,18 +2820,76 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1866,14 +2948,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-3.0.0.tgz",
+      "integrity": "sha512-s9SgS+p3a9Eohe68cSI3fi+hpcZUmXq5P7w0kMlAsWVtR7XbK3ptkZqKT2cK1zLDObJ3sR+8P59sJE0w/KTL1g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "infer-owner": "^1.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1884,6 +3016,62 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2171,6 +3359,29 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2564,6 +3775,30 @@
         "win32"
       ]
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2671,6 +3906,41 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2766,6 +4036,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
@@ -2794,6 +4071,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2852,6 +4130,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2960,6 +4245,17 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2972,12 +4268,79 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -2992,6 +4355,67 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -3039,12 +4463,144 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -3056,15 +4612,29 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/as-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/as-array/-/as-array-2.0.0.tgz",
+      "integrity": "sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3075,6 +4645,33 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -3141,6 +4738,111 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
@@ -3154,6 +4856,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3168,8 +4871,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.14",
@@ -3182,6 +4884,46 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth-connect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.1.0.tgz",
+      "integrity": "sha512-rKcWjfiRZ3p5WS9e5q6msXa07s6DaFAMXoyowV+mb2xQG+oYdw2QEUyKi0Xp95JvXzShlM+oGy5QuqSK6TfC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "^1.0.6"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -3198,8 +4940,8 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -3215,6 +4957,123 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -3277,11 +5136,56 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -3294,6 +5198,43 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/camelcase-css": {
@@ -3357,6 +5298,53 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -3407,6 +5395,171 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cjson": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.3.tgz",
+      "integrity": "sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-parse-helpfulerror": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.3.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3419,6 +5572,30 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
@@ -3437,6 +5614,59 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -3461,12 +5691,327 @@
         "node": ">= 6"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/connect/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-js": {
       "version": "3.49.0",
@@ -3478,6 +6023,151 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/css-line-break": {
@@ -3521,6 +6211,23 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/data-urls": {
@@ -3599,6 +6306,68 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-equal-in-any-order": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-2.2.0.tgz",
+      "integrity": "sha512-lUYf3Oz/HrPcNmKe+S+QSdY5/hzKleftcFBWLwbHNZ5007RUKgN0asWlAHuQGvT9djYd9PYQFiu0TyNS+h3j/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-any": "^4.0.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==",
+      "dev": true,
+      "license": "public domain"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3606,6 +6375,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -3616,6 +6395,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -3634,6 +6424,23 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -3656,6 +6463,32 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3674,14 +6507,21 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.2"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3691,6 +6531,13 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
@@ -3705,12 +6552,36 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3726,6 +6597,30 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -3828,6 +6723,69 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3838,6 +6796,26 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -3845,6 +6823,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-listener": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/events-listener/-/events-listener-1.1.0.tgz",
+      "integrity": "sha512-Kd3EgYfODHueq6GzVfs/VUolh2EgJsS8hkO3KpnDrxVjU3eq63eXM2ujXkhPP+OkeUOhL8CxdfZbQXzryb5C4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/exegesis": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/exegesis/-/exegesis-4.3.0.tgz",
+      "integrity": "sha512-V90IJQ4XYO1SfH5qdJTOijXkQTF3hSpSHHqlf7MstUMDKP22iAvi63gweFLtPZ4Gj3Wnh8RgJX5TGu0WiwTyDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.3",
+        "ajv": "^8.3.0",
+        "ajv-formats": "^2.1.0",
+        "body-parser": "^1.18.3",
+        "content-type": "^1.0.4",
+        "deep-freeze": "0.0.1",
+        "events-listener": "^1.1.0",
+        "glob": "^10.3.10",
+        "json-ptr": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "lodash": "^4.17.11",
+        "openapi3-ts": "^3.1.1",
+        "promise-breaker": "^6.0.0",
+        "qs": "^6.6.0",
+        "raw-body": "^2.3.3",
+        "semver": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">5.0.0"
+      }
+    },
+    "node_modules/exegesis-express": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/exegesis-express/-/exegesis-express-4.0.0.tgz",
+      "integrity": "sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "exegesis": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">5.0.0"
+      }
+    },
+    "node_modules/exegesis/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/exegesis/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/exegesis/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/exegesis/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expect-type": {
@@ -3857,12 +6988,161 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
@@ -3877,8 +7157,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3909,6 +7196,23 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -3969,11 +7273,62 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
+    },
+    "node_modules/filesize": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3986,6 +7341,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/firebase": {
@@ -4063,6 +7440,360 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/firebase-tools": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.15.0.tgz",
+      "integrity": "sha512-WzIDUSe2PRHhsLA2uf1xe8CKTLm+Bbfum4fCduCmjzj4ei5WBszF24Kh9MVS1D3clQbyuIlQKbYhEZZTW+5DUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apphosting/build": "^0.1.7",
+        "@apphosting/common": "^0.0.8",
+        "@electric-sql/pglite": "^0.3.3",
+        "@electric-sql/pglite-tools": "^0.2.8",
+        "@google-cloud/cloud-sql-connector": "^1.3.3",
+        "@google-cloud/pubsub": "^5.2.0",
+        "@inquirer/prompts": "^7.10.1",
+        "@modelcontextprotocol/sdk": "^1.24.0",
+        "abort-controller": "^3.0.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "3.0.1",
+        "archiver": "^7.0.0",
+        "async-lock": "1.4.1",
+        "body-parser": "^1.19.0",
+        "chokidar": "^3.6.0",
+        "cjson": "^0.3.1",
+        "cli-table3": "0.6.5",
+        "colorette": "^2.0.19",
+        "commander": "^5.1.0",
+        "configstore": "^5.0.1",
+        "cors": "^2.8.5",
+        "cross-env": "^7.0.3",
+        "cross-spawn": "^7.0.5",
+        "csv-parse": "^5.0.4",
+        "deep-equal-in-any-order": "^2.0.6",
+        "exegesis": "^4.2.0",
+        "exegesis-express": "^4.0.0",
+        "express": "^4.16.4",
+        "filesize": "^6.1.0",
+        "form-data": "^4.0.1",
+        "fs-extra": "^10.1.0",
+        "fuzzy": "^0.1.3",
+        "gaxios": "^6.7.0",
+        "glob": "^10.5.0",
+        "google-auth-library": "^9.11.0",
+        "ignore": "^7.0.4",
+        "js-yaml": "^3.14.2",
+        "jsonwebtoken": "^9.0.2",
+        "leven": "^3.1.0",
+        "libsodium-wrappers": "^0.7.10",
+        "lodash": "^4.18.0",
+        "lsofi": "^2.0.0",
+        "marked": "^13.0.2",
+        "marked-terminal": "^7.0.0",
+        "mime": "^2.5.2",
+        "minimatch": "^3.0.4",
+        "morgan": "^1.10.0",
+        "node-fetch": "^2.6.7",
+        "open": "^6.3.0",
+        "ora": "^5.4.1",
+        "p-limit": "^3.0.1",
+        "pg": "^8.11.3",
+        "pg-gateway": "^0.3.0-beta.4",
+        "pglite-2": "npm:@electric-sql/pglite@0.2.17",
+        "portfinder": "^1.0.32",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.3.0",
+        "retry": "^0.13.1",
+        "semver": "^7.5.2",
+        "sql-formatter": "^15.3.0",
+        "stream-chain": "^2.2.4",
+        "stream-json": "^1.7.3",
+        "superstatic": "^10.0.0",
+        "tar": "^7.5.11",
+        "tcp-port-used": "^1.0.2",
+        "tmp": "^0.2.3",
+        "triple-beam": "^1.3.0",
+        "universal-analytics": "^0.5.3",
+        "update-notifier-cjs": "^5.1.6",
+        "uuid": "^8.3.2",
+        "winston": "^3.0.0",
+        "winston-transport": "^4.4.0",
+        "ws": "^7.5.10",
+        "yaml": "^2.8.3",
+        "zod": "^3.24.3",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "bin": {
+        "firebase": "lib/bin/firebase.js"
+      },
+      "engines": {
+        "node": ">=20.0.0 || >=22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/firebase-tools/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/firebase-tools/node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/firebase/node_modules/@firebase/auth": {
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
@@ -4083,6 +7814,30 @@
         "@react-native-async-storage/async-storage": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -4120,6 +7875,29 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -4132,6 +7910,31 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -4165,12 +7968,21 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/fuzzy": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
+      "integrity": "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/gaxios": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -4186,12 +7998,12 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4200,8 +8012,8 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -4267,6 +8079,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4280,12 +8129,73 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glob-slash/-/glob-slash-1.0.0.tgz",
+      "integrity": "sha512-ZwFh34WZhZX28ntCMAP1mwyAJkn8+Omagvt/GvA+JQM/qgT0+MR2NPF3vhvgdshfdvDyGZXs8fPXW84K32Wjuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-slasher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glob-slasher/-/glob-slasher-1.0.1.tgz",
+      "integrity": "sha512-5MUzqFiycIKLMD1B0dYOE4hGgLLUZUNGGYO4BExdwT32wUwW3DBOE7lMQars7vB1q43Fb3Tyt+HmgLKsJhDYdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-slash": "^1.0.0",
+        "lodash.isobject": "^2.4.1",
+        "toxic": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -4373,10 +8283,114 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gopd": {
@@ -4391,18 +8405,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/gtoken": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -4432,6 +8463,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4443,6 +8484,57 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heap-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.7.1.tgz",
+      "integrity": "sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -4487,6 +8579,27 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -4525,8 +8638,8 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -4544,11 +8657,79 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -4560,12 +8741,74 @@
         "node": ">=8"
       }
     },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
       "license": "ISC",
-      "optional": true
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/install-artifact-from-github": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.6.0.tgz",
+      "integrity": "sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "bin": {
+        "install-from-cache": "bin/install-from-cache.js",
+        "save-to-github-cache": "bin/save-to-github-cache.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4578,6 +8821,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -4628,6 +8884,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4638,6 +8934,26 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -4645,17 +8961,131 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is2": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
+      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "ip-regex": "^4.1.0",
+        "is-url": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=v0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -4667,6 +9097,25 @@
       "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/join-path": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/join-path/-/join-path-1.1.1.tgz",
+      "integrity": "sha512-jnt9OC34sLXMLJ6YfPQ2ZEKrR9mB5ZbSnQb4LPaOx1c5rTzxpR33L18jjp0r75mGGTJmsil3qwN1B5IBeTnSSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "as-array": "^2.0.0",
+        "url-join": "0.0.1",
+        "valid-url": "^1"
       }
     },
     "node_modules/jose": {
@@ -4684,13 +9133,26 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "29.0.2",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",
@@ -4801,11 +9263,43 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha512-XgP0FGR77+QhUxjXkwOMkC94k3WtqEBfcnjWqhRd82qTat4SWKRE+9kUnynz/shm3I4ea2+qISvTIeGTNU7kJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "^1.1.0"
+      }
+    },
+    "node_modules/json-ptr": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-ptr/-/json-ptr-3.1.1.tgz",
+      "integrity": "sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4818,6 +9312,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -4907,6 +9414,86 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.16.tgz",
+      "integrity": "sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.16.tgz",
+      "integrity": "sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.7.16"
       }
     },
     "node_modules/lightningcss": {
@@ -5196,6 +9783,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -5232,6 +9833,16 @@
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "license": "MIT"
     },
+    "node_modules/lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -5249,6 +9860,58 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -5306,6 +9969,16 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
+    "node_modules/lsofi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lsofi/-/lsofi-2.0.0.tgz",
+      "integrity": "sha512-XTFlOBHeuXnUGuUQI0kBb4O4oQW7qCV7MRGQja1xNpxgrI/jptlly+/5126RiRold1zgyxY520qOZUZ31V0I2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -5326,6 +9999,91 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
+      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5342,6 +10100,29 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5350,6 +10131,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -5400,6 +10191,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -5410,11 +10211,121 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -5427,6 +10338,14 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5447,6 +10366,56 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -5465,6 +10434,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/node-fetch": {
@@ -5496,6 +10481,96 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-gyp": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -5512,6 +10587,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5520,6 +10612,100 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-install-checks": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
+      "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-install-checks/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
+      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^4.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
+      "integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "npm-package-arg": "^11.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-pick-manifest/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -5542,6 +10728,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -5553,22 +10752,128 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
+      "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.1"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -5578,6 +10883,74 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/p-throttle": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-7.0.0.tgz",
+      "integrity": "sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -5590,6 +10963,33 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -5608,10 +11008,51 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5628,6 +11069,119 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-gateway": {
+      "version": "0.3.0-beta.4",
+      "resolved": "https://registry.npmjs.org/pg-gateway/-/pg-gateway-0.3.0-beta.4.tgz",
+      "integrity": "sha512-CTjsM7Z+0Nx2/dyZ6r8zRsc3f9FScoD5UAOlfUx1Fdv/JOIWvRbF7gou6l6vP+uypXQVoYPgw8xZDXgMGvBa4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pglite-2": {
+      "name": "@electric-sql/pglite",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
+      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5667,6 +11221,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
       }
     },
     "node_modules/postcss": {
@@ -5833,6 +11411,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -5860,6 +11481,57 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-breaker": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/promise-breaker/-/promise-breaker-6.0.0.tgz",
+      "integrity": "sha512-BthzO9yTPswGf7etOBiHCVuugs2N01/Q/94dIPls48z2zCmrnDptUUZzfIb+41xq0MnYZ/BzmOd6ikDR4ibNZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -5898,6 +11570,71 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5906,6 +11643,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5937,6 +11703,93 @@
       "optional": true,
       "dependencies": {
         "performance-now": "^2.1.0"
+      }
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/re2": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.24.0.tgz",
+      "integrity": "sha512-pBm6cMaOb0Yb0kg0Sfw/k4LwDMkPScb/NVd7GrEllDwfsPZstsZIo93A6Nn0wZuWJw3h57GdzkrOk81EofKY/g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "install-artifact-from-github": "^1.4.0",
+        "nan": "^2.26.2",
+        "node-gyp": "^12.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
       }
     },
     "node_modules/react": {
@@ -5997,8 +11850,8 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6006,6 +11859,39 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -6041,6 +11927,32 @@
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6082,12 +11994,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6126,6 +12069,22 @@
       "optional": true,
       "engines": {
         "node": ">= 0.8.15"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rolldown": {
@@ -6214,6 +12173,34 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6238,6 +12225,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6256,6 +12253,23 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -6290,12 +12304,316 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/sort-any": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-4.0.7.tgz",
+      "integrity": "sha512-UuZVEXClHW+bVa6ZBQ4biTWmLXMP7y6/jv5arfA0rKk7ZExy+5Zm19uekIqqDx6ZuvUMu7z5Ba9FfBi6FlGXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -6305,6 +12623,54 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.7.3.tgz",
+      "integrity": "sha512-5+zl9Nqg5aNjss0tb1G+StpC4dJKbjv3+g8CL/+V+00PfZop+2RKGyi53ScFl0dr+Dkx1LjmUO54Q3N7K3EtMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
+      }
+    },
+    "node_modules/sql-formatter/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/stackback": {
@@ -6324,6 +12690,16 @@
         "node": ">=0.1.14"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -6331,29 +12707,58 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stream-events": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
       }
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -6362,6 +12767,22 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6384,6 +12805,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -6395,6 +12830,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strnum": {
@@ -6414,8 +12859,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -6438,6 +12883,140 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/superstatic": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-10.0.0.tgz",
+      "integrity": "sha512-4xIenBdrIIYuqXrIVx/lejyCh4EJwEMPCwfk9VGFfRlhZcdvzTd3oVOUILrAGfC4pFUWixzPgaOVzAEZgeYI3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth-connect": "^1.1.0",
+        "commander": "^10.0.0",
+        "compression": "^1.7.0",
+        "connect": "^3.7.0",
+        "destroy": "^1.0.4",
+        "glob-slasher": "^1.0.1",
+        "is-url": "^1.2.2",
+        "join-path": "^1.1.1",
+        "lodash": "^4.17.19",
+        "mime-types": "^2.1.35",
+        "minimatch": "^6.1.6",
+        "morgan": "^1.8.2",
+        "on-finished": "^2.2.0",
+        "on-headers": "^1.0.0",
+        "path-to-regexp": "^1.9.0",
+        "router": "^2.0.0",
+        "update-notifier-cjs": "^5.1.6"
+      },
+      "bin": {
+        "superstatic": "lib/bin/server.js"
+      },
+      "engines": {
+        "node": "20 || 22 || 24"
+      },
+      "optionalDependencies": {
+        "re2": "^1.17.7"
+      }
+    },
+    "node_modules/superstatic/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/superstatic/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/superstatic/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superstatic/node_modules/minimatch": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.3.tgz",
+      "integrity": "sha512-5rvZbDy5y2k40rre/0OBbYnl03en25XPU3gOVO7532beGMjAipq88VdS9OeLOZNrD+Tb0lDhBJHZ7Gcd8qKlPg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/superstatic/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -6508,6 +13087,97 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tcp-port-used": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
+      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.1",
+        "is2": "^2.0.6"
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/teeny-request": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
@@ -6565,6 +13235,48 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
@@ -6694,6 +13406,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6705,6 +13427,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tough-cookie": {
@@ -6720,11 +13452,41 @@
         "node": ">=16"
       }
     },
+    "node_modules/toxic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toxic/-/toxic-1.0.1.tgz",
+      "integrity": "sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.10"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -6733,11 +13495,124 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "6.19.7",
@@ -6753,6 +13628,73 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universal-analytics": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.5.3.tgz",
+      "integrity": "sha512-HXSMyIcf2XTvwZ6ZZQLfxfViRm/yTGoRgDeTbojtq6rezeyKB0sTBcKH2fhddnteAHRcHiKgr/ACpbgjGOC6RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.18.2"
+      }
+    },
+    "node_modules/universal-analytics/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -6785,12 +13727,77 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/update-notifier-cjs": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/update-notifier-cjs/-/update-notifier-cjs-5.1.7.tgz",
+      "integrity": "sha512-eZWTh8F+VCEoC4UIh0pKmh8h4izj65VvLhCpJpVefUxdYe0fU3GBrC4Sbh1AoWA/miNPAb6UVlp2fUQNsfp+3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "isomorphic-fetch": "^3.0.0",
+        "pupa": "^2.1.1",
+        "registry-auth-token": "^5.0.1",
+        "registry-url": "^5.1.0",
+        "semver": "^7.3.7",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/update-notifier-cjs/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/utrie": {
       "version": "1.0.2",
@@ -6812,6 +13819,39 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -7488,6 +14528,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -7526,6 +14576,13 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -7546,6 +14603,22 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -7561,6 +14634,67 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/wrap-ansi": {
@@ -7580,12 +14714,83 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
       "license": "ISC",
-      "optional": true
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
@@ -7604,6 +14809,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7619,6 +14834,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -7647,17 +14878,118 @@
         "node": ">=12"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,20 +19,25 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^3.0.4",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.3",
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.2.1",
+        "cross-env": "^10.1.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "firebase-tools": "^15.15.0",
         "jsdom": "^29.0.2",
         "postcss": "^8.4.48",
+        "supertest": "^7.2.2",
         "tailwindcss": "^3.4.15",
         "vite": "^5.4.10",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.4",
+        "wait-on": "^9.0.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -733,6 +738,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1690,6 +1702,72 @@
       "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
       "license": "Apache-2.0"
     },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-3.0.4.tgz",
+      "integrity": "sha512-FxDc5rnTtt266PTs3dOkf4ZDq+P223TrFWXka/yG6gSFy3Es/iKwWh3bX9pROobHgbbrAd7she9+687yOC2z+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node-fetch": "2.6.4",
+        "node-fetch": "2.6.7"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "firebase": "^10.0.0"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/@types/node-fetch": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@firebase/storage": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.2.tgz",
@@ -2270,6 +2348,60 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@hono/node-server": {
@@ -2910,6 +3042,20 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3018,6 +3164,16 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3027,6 +3183,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -4636,6 +4808,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4736,6 +4915,28 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/balanced-match": {
@@ -5691,6 +5892,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compress-commons": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
@@ -6013,6 +6224,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-js": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
@@ -6127,22 +6345,21 @@
       "license": "MIT"
     },
     "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.1"
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
       },
       "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -6416,6 +6633,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/didyoumean": {
@@ -7002,7 +7230,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7196,6 +7423,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -7575,6 +7809,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/firebase-tools/node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/firebase-tools/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7823,6 +8076,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -7886,6 +8160,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -9105,6 +9397,25 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/joi": {
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/join-path": {
       "version": "1.1.1",
@@ -11233,6 +11544,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/portfinder": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
@@ -12885,6 +13243,40 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/superstatic": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-10.0.0.tgz",
@@ -12971,6 +13363,21 @@
       "license": "MIT",
       "dependencies": {
         "isarray": "0.0.1"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {
@@ -14526,6 +14933,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.5.tgz",
+      "integrity": "sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.15.0",
+        "joi": "^18.1.2",
+        "lodash": "^4.18.1",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.2"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:local": "concurrently -n emu,api,web -c yellow,cyan,green \"npm:emu\" \"npm:api\" \"npm:dev\"",
     "test:unit": "vitest run tests/unit",
     "test:rules": "firebase emulators:exec --only firestore --project demo-saikaku 'vitest run tests/rules'",
-    "test:api": "firebase emulators:exec --only auth,firestore --project demo-saikaku 'cross-env MOCK_ANTHROPIC=1 vitest run tests/api'",
+    "test:api": "firebase emulators:exec --only auth,firestore --project demo-saikaku 'cross-env NODE_ENV=test MOCK_ANTHROPIC=1 TEST_BYPASS_AUTH=1 vitest run tests/api'",
     "test:e2e": "node scripts/test-e2e-orchestrator.mjs",
     "test:all": "npm run test:unit && npm run test:rules && npm run test:api && npm run test:e2e"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "node node_modules/vite/bin/vite.js build",
-    "preview": "node node_modules/vite/bin/vite.js preview"
+    "preview": "node node_modules/vite/bin/vite.js preview",
+    "emu": "PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH firebase emulators:start --project demo-saikaku",
+    "api": "node server.js",
+    "dev:local": "concurrently -n emu,api,web -c yellow,cyan,green \"npm:emu\" \"npm:api\" \"npm:dev\""
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
@@ -25,6 +28,10 @@
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.3",
     "autoprefixer": "^10.4.20",
+    "concurrently": "^9.2.1",
+    "dotenv": "^17.4.2",
+    "express": "^5.2.1",
+    "firebase-tools": "^15.15.0",
     "jsdom": "^29.0.2",
     "postcss": "^8.4.48",
     "tailwindcss": "^3.4.15",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
     "preview": "node node_modules/vite/bin/vite.js preview",
     "emu": "PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH firebase emulators:start --project demo-saikaku",
     "api": "node server.js",
-    "dev:local": "concurrently -n emu,api,web -c yellow,cyan,green \"npm:emu\" \"npm:api\" \"npm:dev\""
+    "dev:local": "concurrently -n emu,api,web -c yellow,cyan,green \"npm:emu\" \"npm:api\" \"npm:dev\"",
+    "test:unit": "vitest run tests/unit",
+    "test:rules": "firebase emulators:exec --only firestore --project demo-saikaku 'vitest run tests/rules'",
+    "test:api": "firebase emulators:exec --only auth,firestore --project demo-saikaku 'cross-env MOCK_ANTHROPIC=1 vitest run tests/api'",
+    "test:e2e": "node scripts/test-e2e-orchestrator.mjs",
+    "test:all": "npm run test:unit && npm run test:rules && npm run test:api && npm run test:e2e"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
@@ -23,19 +28,24 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^3.0.4",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.3",
     "autoprefixer": "^10.4.20",
     "concurrently": "^9.2.1",
+    "cross-env": "^10.1.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "firebase-tools": "^15.15.0",
     "jsdom": "^29.0.2",
     "postcss": "^8.4.48",
+    "supertest": "^7.2.2",
     "tailwindcss": "^3.4.15",
     "vite": "^5.4.10",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "wait-on": "^9.0.5"
   }
 }

--- a/plans/issue-1-2-badge-history.md
+++ b/plans/issue-1-2-badge-history.md
@@ -1,0 +1,449 @@
+# 才覚診断: 診断済みバッジ + 履歴 + 2回上限 (issue #1, #2 統合)
+
+> Round 1 + Round 2 フィードバック完全反映済み（v3 final）。Codex/Gemini 両者の指摘を統合。
+> **重要設計変更**: Reservation Transaction（事前インクリメント）パターンを採用し、並行リクエスト時のLLM多重発火を完全に防ぐ。
+
+## 概要
+
+- **目的**: SelectScreen に診断済みバッジを表示し、各診断の履歴閲覧と最大2回までの試行制限を実装する
+- **対象issue**: #1 (UX: 診断済みバッジ), #2 (Feature: 履歴 + 2回制限)
+- **スコープ**:
+  - Architecture (`results/{uid}`) と MATRIX (`uaam_results/{uid}`) の両方
+  - SelectScreen UI、履歴閲覧 UI、API (`api/analyze.js` / `api/uaam.js`)、Firestore rules
+  - **E2E自動テスト**: Playwright（代表3フロー）+ API統合テスト（Transaction/migration厚め）+ rules 単体テスト
+- **実装担当**: Codex (assign-codex 経由)。Codex の差分は **必ずクロードが目視レビュー** してからコミット
+
+## ローカル開発・テスト環境
+
+- `npm run emu` — Firebase emulator (auth:9099, firestore:8080, UI:4000)
+- `npm run api` — API server (`server.js`)
+- `npm run dev` — Vite dev server
+- `npm run dev:local` — concurrently で同時起動
+- 新規追加: `@playwright/test`, `@firebase/rules-unit-testing`, `supertest`, `msw` (LLM mock)
+
+---
+
+## 設計判断（Round 1 修正版）
+
+### A. データモデル: サブコレクション + Read-Time Fallback + サイズ分離
+
+Codex指摘を受けて、Firestore 1MiB doc 制限を前提に **summary / full / raw** をフィールドレベルで分離。
+
+```
+results/{uid}                                  ← 親doc（一覧用summary, 後方互換用 result も継続）
+  ├─ attemptCount: number                       ← 0/1/2
+  ├─ latestAttemptId: string
+  ├─ pendingAttemptId: string | null            ← 予約中（後述 C のReservation用）
+  ├─ result: {...}                              ← 既存。最新attemptサマリ後方互換
+  └─ attempts/{attemptId}                       ← サブコレクション（履歴）
+       ├─ summary: { typeName, kakuchiiki, score, createdAt } ← 一覧表示に十分なミニマム
+       ├─ full:    { result, analysis, scores } ← 結果再表示に必要な構造化データ
+       ├─ raw:     { input: { talent, value, passion, q1, q2, q3, … } } ← 入力全文（大きければ別docに退避可）
+       ├─ status:  'pending' | 'committed'      ← Reservation状態
+       └─ createdAt: serverTimestamp
+```
+
+uaam_results も同構造。
+
+**設計ガイドライン**:
+- 1 attempt doc は **summary + full** で必ず収まるよう設計（< 200KB目安）
+- `raw.input` が大きい場合は `attempts/{aid}/raw/0` のように別doc化
+- 親docの `result` は legacy 互換のためのサマリ（既存 admin/integrate API が依存）
+
+**Read-Time Fallback (Gemini 提案)**: HistoryScreen で `attempts` が空 + 親docに `result`/`analysis` あり → **親docを履歴1件目としてクライアント側で合成表示**。これにより遅延migrationでも履歴が空にならない。
+
+### B. セキュリティ: Firestore rules 厳格化（型・削除・create も含めて）
+
+Codex Round 2 指摘: `affectedKeys().hasOnly(...)` だけでは型/削除/不正値を縛れない。
+
+```js
+// 親doc results/{uid}
+match /results/{uid} {
+  allow read: if request.auth.uid == uid;
+
+  // create: 認証直後の consent doc 作成のみ許可
+  allow create: if request.auth.uid == uid
+    && request.resource.data.keys().hasOnly(['consentAt'])
+    && request.resource.data.consentAt is timestamp;
+
+  // update: クライアントが触れるのは consentAt / selectedKakuchiiki のみ
+  // - 既存フィールドの削除を拒否
+  // - 型と長さも検証
+  allow update: if request.auth.uid == uid
+    && request.resource.data.diff(resource.data).affectedKeys()
+       .hasOnly(['consentAt', 'selectedKakuchiiki'])
+    && (!('consentAt' in request.resource.data) || request.resource.data.consentAt is timestamp)
+    && (!('selectedKakuchiiki' in request.resource.data)
+         || (request.resource.data.selectedKakuchiiki is string
+             && request.resource.data.selectedKakuchiiki.size() < 200))
+    && resource.data.keys().hasAll(resource.data.keys());  // 既存フィールド削除禁止 (※実際にはsentinel pattern)
+
+  allow delete: if false;
+}
+
+match /results/{uid}/attempts/{aid} {
+  allow read: if request.auth.uid == uid;
+  allow write, delete: if false;          // Admin SDK 経由のみ
+}
+
+// uaam_results は consentAt 不要なので 全面 read-only に近い
+match /uaam_results/{uid} {
+  allow read: if request.auth.uid == uid;
+  allow write, delete: if false;
+}
+match /uaam_results/{uid}/attempts/{aid} {
+  allow read: if request.auth.uid == uid;
+  allow write, delete: if false;
+}
+```
+
+**重要事項 (Codex 指摘)**:
+- `ResultScreen.jsx:296` の `setDoc(..., { selectedKakuchiiki }, { merge: true })` が **初回 create** になる経路がないか確認必要。consent doc が必ず先に作られる前提が崩れると拒否される。テストseed/auth復元で要検証
+- 既存フィールド削除禁止は Firestore rules では完全表現が難しいため、**API側でも `merge: true` を徹底**して防御層を二重化
+
+### C. 2回上限 + LLMコスト保護: **Reservation Transaction（事前インクリメント）**
+
+> **Round 2 で根本的に変更**: Gemini 指摘「LLM呼び出し前に枠を予約しないとコスト保護にならない」を採用。
+> 連打・並行リクエストでも LLM が一度しか呼ばれない。
+
+**全体フロー**:
+```
+[Reserve Transaction]   ← LLM 呼び出し前に枠を予約（attemptCount を 1 進める）
+        ↓ 成功
+[LLM 呼び出し]          ← Anthropic API
+        ↓ 成功
+[Commit Transaction]    ← attempt doc を pending → committed に書き換え + 親doc result 更新
+        ↓ 失敗 (LLM error 等)
+[Rollback Transaction]  ← attemptCount を1戻す + pending attempt を削除（or status=failed）
+```
+
+#### Reservation Transaction (LLM 前)
+```js
+const { attemptId, attemptRef } = await db.runTransaction(async tx => {
+  const cur = await tx.get(docRef);
+  const data = cur.exists ? cur.data() : {};
+
+  // 既存 pending があれば、別リクエストが処理中 → 409
+  if (data.pendingAttemptId) {
+    throw new ConflictError('処理中のリクエストがあります');
+  }
+
+  // legacy 自動 migration を同 Transaction 内で実行
+  // attemptCount 未設定 + result/analysis あり → legacy attempt として deterministic ID で記録
+  let count = data.attemptCount ?? 0;
+  if (count === 0 && (data.result || data.analysis)) {
+    const legacyRef = docRef.collection('attempts').doc('legacy-v1');  // ← deterministic ID
+    tx.set(legacyRef, {
+      summary: extractSummary(data),
+      full:    extractFull(data),
+      raw:     extractRaw(data),
+      status:  'committed',
+      isLegacy: true,
+      createdAt: data.createdAt ?? FieldValue.serverTimestamp(),
+    });
+    count = 1;
+  }
+
+  if (count >= 2) {
+    throw new LimitExceededError('診断は最大2回までです');
+  }
+
+  // 新 attempt を pending で予約 + attemptCount を事前インクリメント
+  const newAttemptRef = docRef.collection('attempts').doc();
+  tx.set(newAttemptRef, {
+    status: 'pending',
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  tx.set(docRef, {
+    attemptCount: count + 1,
+    pendingAttemptId: newAttemptRef.id,
+    updatedAt: FieldValue.serverTimestamp(),
+    ...(!data.createdAt ? { createdAt: FieldValue.serverTimestamp() } : {}),
+  }, { merge: true });
+
+  return { attemptId: newAttemptRef.id, attemptRef: newAttemptRef };
+});
+```
+
+#### LLM 呼び出し（Anthropic）
+
+#### Commit Transaction (LLM 後成功時)
+```js
+await db.runTransaction(async tx => {
+  // pending → committed に書き換え + 結果データを格納
+  tx.set(attemptRef, {
+    summary: { typeName, kakuchiiki, /* ... */ },
+    full:    { result, analysis, scores },
+    raw:     { input },
+    status:  'committed',
+  }, { merge: true });
+
+  // 親doc: pending 解放 + latestAttemptId 更新 + 後方互換 result も更新
+  tx.set(docRef, {
+    pendingAttemptId: null,
+    latestAttemptId: attemptId,
+    result,  // 後方互換
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true });
+});
+```
+
+#### Rollback Transaction (LLM 失敗時)
+```js
+await db.runTransaction(async tx => {
+  const cur = await tx.get(docRef);
+  // 自分の予約だった場合のみ rollback
+  if (cur.data()?.pendingAttemptId !== attemptId) return;
+
+  tx.delete(attemptRef);
+  tx.set(docRef, {
+    attemptCount: FieldValue.increment(-1),
+    pendingAttemptId: null,
+  }, { merge: true });
+});
+```
+
+**特徴**:
+- **LLMコスト保護**: 並行N件のリクエスト全てが Reservation Transaction で奪い合うので、attemptCount=0 のとき同時2件来ても **片方しかLLM呼ばれない**
+- **冪等な migration**: `legacy-v1` deterministic ID で再実行しても二重作成されない
+- **Lock 開放**: `pendingAttemptId` が立っている間は別リクエストが入れない（連打防止）。タイムアウト復旧は別 cron / TTLで対応するか、long-running protection は MVP では割愛（リスク：ユーザがリクエスト中にブラウザ閉じると pending 残置 → 補修UI or 管理ボタンで対応）
+- **rules 適合**: クライアントから `attempts` には書き込めない。全て Admin SDK 経由
+
+### D. UI 整合性（Codex/Gemini 指摘集約）
+
+#### SelectScreen バッジ
+壊れたデータ（`attemptCount=0` だが `result` 存在）に耐えるため `Math.max` で防御:
+```js
+displayAttemptCount = Math.max(
+  data?.attemptCount ?? 0,
+  (data?.result || data?.analysis) ? 1 : 0
+);
+```
+**ただし**サーバー側の上限判定はこの表示ロジックに依存しない。サーバーは Reservation Transaction 内の migration で正規化してから判定する。
+
+#### HistoryScreen
+- `attempts` subcoll を `getDocs` で取得
+- 空 + 親docに `result`/`analysis` あり → 親doc を「擬似 attempt」として1件目に追加（Read-Time Fallback）
+- 詳細遷移時は `attemptAdapter(attempt, kind)` で ResultScreen/UAAMResultScreen が期待する props 形状に変換（`src/utils/attemptAdapter.js` 新設）
+
+#### MATRIX パスワードゲート（**(a) 受験者制限と確定済み**）
+`UAAM_PASS = 'kokusogaku'` の意図は「許可した人だけが MATRIX 診断を受けられる」受験者制限（つかさ確認 2026-05-02）。
+
+**確定方針**: パスワードは **新規診断開始のみ** をガードする。
+- バッジ・履歴一覧・履歴詳細はパス入力前から閲覧可
+- 「診断を開始する」ボタンクリック時のみ既存 `UAAM_PASS` モーダル表示
+- 結果プライバシーはこのパスワードの責務ではない（家族・同居人に見られたくない場合は別レイヤーで対処）
+
+### E. テスト戦略（Codex Round 2 指摘反映）
+
+#### LLM mock は API server 側で行う（MSW不採用）
+**Codex 指摘**: LLM呼び出しは Node API server から SDK 経由で発生 → ブラウザ側 MSW では捕捉不可。
+
+**採用方式**:
+- `api/lib/anthropicClient.js` を新設し、Anthropic SDK をラップ。`process.env.MOCK_ANTHROPIC === '1'` のときは fixture JSON を返す mock provider に切り替え
+- `tests/fixtures/anthropic/architecture-1.json` 等に固定レスポンスを置く
+- API統合テスト・E2E どちらも `MOCK_ANTHROPIC=1` で起動した API server を共有
+- vitest 単体テストでは `vi.mock('@anthropic-ai/sdk')` で SDK module mock
+
+#### `npm run test:all` の実行設計（Codex 指摘で具体化）
+emulator/API/Vite の readiness を確実に揃えるため、専用 orchestrator スクリプトを用意:
+
+```json
+"test:unit":  "vitest run tests/unit",
+"test:rules": "firebase emulators:exec --only firestore --project demo-saikaku 'vitest run tests/rules'",
+"test:api":   "firebase emulators:exec --only auth,firestore --project demo-saikaku 'MOCK_ANTHROPIC=1 vitest run tests/api'",
+"test:e2e":   "node scripts/test-e2e-orchestrator.mjs",
+"test:all":   "npm run test:unit && npm run test:rules && npm run test:api && npm run test:e2e"
+```
+
+`scripts/test-e2e-orchestrator.mjs` の責務:
+1. firebase emulator (auth+firestore) を bg 起動
+2. `wait-on tcp:9099 tcp:8080` で ready 待ち
+3. `MOCK_ANTHROPIC=1 node server.js` を bg 起動 → `wait-on http://localhost:3000/api/health`（health endpoint 追加）
+4. `vite preview` または `vite` を bg 起動 → `wait-on http://localhost:5173`
+5. `playwright test` 実行
+6. exit 時に全 bg を SIGTERM
+
+ポート衝突チェックも実装（既存プロセス検出 → エラー終了）
+
+#### Playwright は3フローに絞る（Codex 指摘）
+1. バッジ表示フロー（新規→1回診断→バッジ「1/2」+ 履歴1件）
+2. 履歴遷移フロー（履歴一覧→詳細→戻る）
+3. 上限抑止フロー（attemptCount=2 状態で診断開始→モーダル）
+
+複雑な migration / 同時実行 / fallback は **API統合テストで厚く** 検証する（Playwrightでやらない）。
+
+#### 同時実行テストの条件（Reservation方式に対応して期待値変更）
+- **attemptCount=0** で同時2リクエスト → **一方200・一方409 (`pendingAttemptId` 競合)**, 最終 `attemptCount=1`、LLM mock の call count = **1**
+- **attemptCount=1** で同時2リクエスト → 一方200・一方409, 最終 `attemptCount=2`、LLM call = 1
+- **attemptCount=2** で同時2リクエスト → 両方429（preflight LimitExceeded）、LLM call = 0
+- 連打防止確認: 1リクエスト処理中（pending残）に2リクエスト目を投げる → 409
+
+ユーザーがネットワーク遅延・連打で2回分を一瞬で消費する事故を物理的に防ぐ。
+
+---
+
+## Phase 0: 作業準備
+
+- [x] [id:setup] [required] 作業ブランチ作成 `git checkout -b feat/issue-1-2-badge-history`
+- [x] [id:design-confirm] [required] 設計判断の最終確認（つかさレビュー）
+  - Reservation Transaction 方式を採用すること
+  - MATRIX のパスワード = (a) 受験者制限 で確定済み（2026-05-02）→ バッジ・履歴は常時表示
+
+## Phase 1: バックエンド基盤 `depends-on: design-confirm`
+
+- [x] [id:rules] Firestore rules 厳格化
+  - [x] [id:rules-edit] [required] 親doc `update` 許可フィールドを `consentAt`/`selectedKakuchiiki` に限定。`attempts` は `read` のみ、`write: if false`
+  - [x] [id:rules-emulator] emulator で動作確認 `depends-on: rules-edit`
+
+- [x] [id:api-helper] [required] `api/lib/attempts.js` 新規作成（Codex 委譲）
+  - [x] [id:helper-reserve] `reserveAttempt(coll, uid)`: Reservation Transaction（legacy migration を内包、pending 予約、上限チェック）→ `{ attemptId, attemptRef }` を返す or `LimitExceededError`/`ConflictError`
+  - [x] [id:helper-commit]  `commitAttempt(attemptRef, docRef, attemptId, payload)`: 結果データ書き込み + 親doc 更新
+  - [x] [id:helper-rollback] `rollbackAttempt(attemptRef, docRef, attemptId)`: pending 取り消し（自分の予約だった場合のみ）
+
+- [x] [id:anthropic-wrapper] [required] `api/lib/anthropicClient.js` 新設（Codex 委譲）
+  - 通常モード: 既存 SDK ラップ
+  - `MOCK_ANTHROPIC=1`: `tests/fixtures/anthropic/*.json` から固定レスポンス返却
+
+- [x] [id:api-rewrite] API 改修 `depends-on: api-helper, anthropic-wrapper`
+  - [x] [id:api-analyze] `api/analyze.js` 改修
+    - **入口でreserveAttempt('results', uid)** → 失敗なら 429（LimitExceeded）/ 409（Conflict）即返却（LLM呼ばない）
+    - Anthropic 呼び出し（通常 or mock）
+    - 成功 → commitAttempt
+    - 失敗 → rollbackAttempt → 500 + リトライ可能メッセージ
+  - [x] [id:api-uaam] `api/uaam.js` 同様に改修
+  - [x] [id:api-health] `/api/health` endpoint 追加（test orchestrator用）
+
+- [x] [id:api-test] [required] API smoke test (curl + emulator) `depends-on: api-rewrite`
+  - 1回目: 200, attemptCount=1
+  - 2回目: 200, attemptCount=2
+  - 3回目: 429（pre-Reservation で reject、LLM mock のcall count 加算されないこと）
+  - 連打: 同時2req → 一方200・一方409 (pending 競合)、LLM call=1
+
+## Phase 2: フロント - SelectScreen バッジ `depends-on: rules-edit`
+
+- [x] [id:ui-badge-hook] [required] `useDiagnosisStatus(user)` カスタムフック新設（Codex 委譲）
+  - 並列 `getDoc(results/{uid})` `getDoc(uaam_results/{uid})`
+  - **legacy fallback**: `attemptCount ?? (result || analysis ? 1 : 0)`
+  - エラー時は `null` を返してメニュー継続表示
+  - （オプション）`onSnapshot` で更新検知（Layout Shift防止 by Gemini提案）
+
+- [x] [id:ui-badge-render] SelectScreen にバッジ描画 `depends-on: ui-badge-hook`
+  - 才覚領域: ゴールド pill「診断済み (n/2)」
+  - MATRIX: ブルー pill「診断済み (n/2)」（パス入力前から表示）
+  - 取得中はバッジ非表示
+  - 既存 hover 演出を破壊しない
+
+- [x] [id:ui-limit] [parallel] attemptCount===2 状態の UI `depends-on: ui-badge-hook`
+  - CTA 下に「診断は最大2回まで実施済み」表示
+  - クリック時にモーダル「履歴を見る」誘導
+
+## Phase 3: フロント - 履歴UI `depends-on: api-test, ui-badge-render`
+
+- [x] [id:adapter] [required] `src/utils/attemptAdapter.js` 新設（Codex 委譲）
+  - `attemptToResultProps(attempt, kind)` で ResultScreen/UAAMResultScreen が期待する props 形状に変換
+  - 親doc を擬似 attempt として渡せるよう `legacyDocToAttempt(parentDoc, kind)` も用意
+
+- [x] [id:ui-history-screen] [required] `src/screens/HistoryScreen.jsx` `depends-on: adapter`
+  - props: `user`, `kind` ('saikaku'|'uaam'), `onBack`, `onSelectAttempt`
+  - `getDocs(collection(...,'attempts')` `orderBy('createdAt','desc')`
+  - **Read-Time Fallback**: attempts 空 + 親doc に result/analysis あり → 親docを擬似1件目に
+  - 一覧UI: 日時 + タイプ名
+
+- [x] [id:ui-history-link] SelectScreen に「履歴を見る (n)」リンク追加 `depends-on: ui-history-screen`
+  - **MATRIX も パス入力前から表示・遷移可能**（一貫性確保）
+
+- [x] [id:ui-history-route] `src/App.jsx` に screen 'history-saikaku' / 'history-uaam' 追加 `depends-on: ui-history-screen`
+  - 詳細遷移は ResultScreen/UAAMResultScreen に `attemptData` props で渡す
+
+- [x] [id:ui-result-attempt] [required] ResultScreen / UAAMResultScreen に `attemptData` props 対応 `depends-on: ui-history-route, adapter`
+  - `attemptData` 渡された場合は Firestore 自動読み込みをスキップ
+  - 「最新の結果に戻る」ボタン
+
+## Phase 4: テスト自動化 `depends-on: api-rewrite, ui-history-route`
+
+- [x] [id:test-deps] [required] devDependencies追加: `@playwright/test`, `@firebase/rules-unit-testing`, `supertest`, `wait-on`
+- [x] [id:test-fixtures] [required] `tests/fixtures/anthropic/*.json` 配置 `depends-on: anthropic-wrapper`
+  - Architecture用 (`results-1.json`, `results-2.json`)、MATRIX用 (`uaam-1.json`, `uaam-2.json`)
+- [x] [id:test-scripts] [required] `package.json` scripts 整備 `depends-on: test-deps`
+  - `test:unit` / `test:rules` / `test:api`（`MOCK_ANTHROPIC=1` + emulators:exec）/ `test:e2e`（orchestrator経由）/ `test:all`
+- [x] [id:e2e-orchestrator] [required] `scripts/test-e2e-orchestrator.mjs` 作成 `depends-on: test-deps`
+  - emulator → API server (MOCK_ANTHROPIC=1) → vite preview を順次起動、wait-onで readiness 待ち、playwright実行、終了時に全停止
+- [x] [id:playwright-config] `playwright.config.js` 作成 `depends-on: test-deps`
+  - `baseURL: http://localhost:5173`、storageState で認証 seed
+
+- [x] [id:test-rules] Firestore rules 単体テスト `depends-on: rules-edit, test-scripts`
+  - [x] [id:test-rules-attempts-write] [required] `attempts` への直接write が **拒否される** こと
+  - [x] [id:test-rules-attempts-read] [required] 本人のみ read 可、他人は不可
+  - [x] [id:test-rules-parent-fields] [required] 親doc 更新は許可フィールドのみ
+  - [x] [id:test-rules-types] [required] 型・サイズ違反 (`selectedKakuchiiki` に巨大文字列、`consentAt` に non-timestamp) 拒否
+  - [x] [id:test-rules-delete] [required] delete 操作が拒否される
+  - [x] [id:test-rules-create-flow] [required] consent doc 作成 → selectedKakuchiiki update が成立する正常フロー確認
+
+- [x] [id:test-api] API 統合テスト（厚め） `depends-on: api-test, test-fixtures, test-scripts`
+  - [x] [id:test-api-basic] [required] 1/2/3回目挙動 + 3回目で Anthropic mockの call count = 0
+  - [x] [id:test-api-concurrent-0] [required] attemptCount=0で同時2req → **一方200・一方409**, LLM call=1
+  - [x] [id:test-api-concurrent-1] [required] attemptCount=1で同時2req → 一方200・一方409, LLM call=1
+  - [x] [id:test-api-concurrent-2] [required] attemptCount=2で同時2req → 両方429, LLM call=0
+  - [x] [id:test-api-pending-block] [required] pending 残存中に新規req → 409
+  - [x] [id:test-api-rollback] [required] LLM 失敗時の rollback で attemptCount が元に戻る
+  - [x] [id:test-api-migration] [required] legacy親doc → 1回診断 → attempts に `legacy-v1` + 新id、attemptCount=2
+  - [x] [id:test-api-migration-idempotent] [required] migration 連続2回呼び出しで `legacy-v1` 重複作成されない (deterministic ID 検証)
+
+- [x] [id:test-e2e] Playwright E2E（代表3フローのみ） `depends-on: ui-history-route, playwright-config`
+  - [x] [id:e2e-fixtures] [required] emulator user 作成 + Firestore seed helper
+  - [x] [id:e2e-badge-flow] [required] バッジ表示: 新規→診断1回（mockLLM）→「1/2」表示
+  - [x] [id:e2e-history-flow] [required] 履歴遷移: 1件履歴→詳細→戻る、Read-Time Fallback ケースも含む
+  - [x] [id:e2e-limit-flow] [required] attemptCount=2 状態で診断開始 → モーダル抑止
+
+- [x] [id:test-unit-ui] SelectScreen ユニット (vitest+RTL)
+  - [x] [id:test-unit-badge] [required] attemptCount 0/1/2 + legacy fallback パターン網羅
+
+## Phase 5: 既存ユーザー migration 検証 `depends-on: test-api-migration`
+
+- [x] [id:migration-staging] staging or 自分用本番アカウントで実施テスト（注意: 必ずバックアップ）
+
+## Phase 6: 品質ゲート `depends-on: test-e2e, test-api-basic, test-rules-attempts-write`
+
+- [x] [id:codex-review] [required] `/codex-code-review` 実行
+- [x] [id:codex-fix] 重大/重要指摘を解消 `depends-on: codex-review`
+- [x] [id:test-all-green] [required] `npm run test:all` 全パス `depends-on: codex-fix`
+- [x] [id:claude-final-review] [required] **クロード最終レビュー**: `git diff` 全件目視 `depends-on: codex-fix`
+- [x] [id:ui-review] [parallel] `/ui-skills` UI演出チェック `depends-on: codex-fix`
+
+## Phase 7: ドキュメント同期 `depends-on: claude-final-review`
+
+- [x] [id:docs] [required] ドキュメント更新
+  - [x] [id:docs-readme] `README.md` に「最大2回」「履歴閲覧」「`npm run test:all`」を追記
+  - [x] [id:docs-spec] `docs/design-rationale.md` にサブコレクション/Transaction境界/Read-Time Fallback採用理由を記録
+  - [x] [id:docs-rules] `firestore.rules` のコメントで write 禁止理由を明記
+  - [x] [id:docs-test] `docs/testing.md` にE2E実行手順 + LLM mock運用を記載
+
+## Phase 8: 完了 `depends-on: docs`
+
+- [x] [id:pr] PR作成（タイトル: `feat: 診断済みバッジ・履歴閲覧・2回上限を実装 (closes #1, closes #2)`）
+- [x] [id:review-req] つかさレビュー依頼 `depends-on: pr`
+
+---
+
+## 完了条件
+
+- [x] 全タスクが `[x]` に更新
+- [x] `npm run test:all` がローカル一発で全パス（orchestrator が emulator/API/Vite 自動起動）
+- [x] **rules テスト**: 型・削除・直書きすべて拒否確認
+- [x] **API テスト**: 同時2req で LLM mock call count=1（コスト保護担保）
+- [x] **同時実行 (Reservation)**: attemptCount=0 同時2req → 一方200・一方409、LLM 1回のみ
+- [x] **migration deterministic**: `legacy-v1` ID で冪等
+- [x] **rollback**: LLM失敗で attemptCount が元に戻る
+- [x] **Read-Time Fallback**: attempts 空でも履歴1件表示
+- [x] **MATRIX 方針**: (a) 受験者制限で確定済み → バッジ・履歴・詳細はパス前から閲覧可、診断開始のみゲート
+- [x] PR がマージ可能状態
+
+## リスク・前提
+
+- **rules破壊的変更**: 既存 `LoginScreen.jsx` (`consentAt` 書き込み) と `ResultScreen.jsx:296` (`selectedKakuchiiki` 書き込み) を許可フィールドに含めて維持。型・サイズ制約を rules で追加するので、不正値が投入されるテストパスがあれば検出される。Phase 2 ui-badge / Phase 3 ui-history の前に rules テストでカバー
+- **Pending残存リスク**: ユーザがリクエスト中にブラウザを閉じる → `pendingAttemptId` が残り続ける → そのユーザはリクエスト不能。MVPでは管理画面（既存 `AdminScreen`）に「保留解除」ボタンを追加するか、TTLベースの自動 cleanup を後追い。**v1 では手動対応で進め、別issue化**
+- **Reservation Transaction の rollback 失敗**: LLM 呼び出しと rollback Transaction の間でサーバーが死ぬと pending 残存 → 同上の手動対応
+- **MATRIX 履歴の公開可否**: (a) 受験者制限で確定済み（2026-05-02）。バッジ・履歴は常時表示で実装
+- **テスト orchestrator のポート衝突**: ローカル開発で emulator/API/Vite が起動中だと `test:all` が衝突。orchestrator 起動時にポート使用中チェックを実装してエラー早期終了
+- **Layout Shift (Gemini オプション提案)**: バッジ取得時のチラつき軽減のため `onSnapshot` 採用も検討可。Phase 2 ui-badge-hook の拡張オプション

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 60_000,
+  fullyParallel: false,
+  retries: 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: 'tests/e2e',
   timeout: 60_000,
   fullyParallel: false,
+  workers: 1,
   retries: 0,
   reporter: 'list',
   use: {

--- a/scripts/test-e2e-orchestrator.mjs
+++ b/scripts/test-e2e-orchestrator.mjs
@@ -18,7 +18,10 @@ const sharedEnv = {
   FIRESTORE_EMULATOR_HOST: 'localhost:8080',
   FIREBASE_AUTH_EMULATOR_HOST: 'localhost:9099',
   FIREBASE_PROJECT_ID: 'demo-saikaku',
+  GCLOUD_PROJECT: 'demo-saikaku',
   MOCK_ANTHROPIC: '1',
+  NODE_ENV: 'test',
+  TEST_BYPASS_AUTH: '1',
 };
 
 function log(message) {

--- a/scripts/test-e2e-orchestrator.mjs
+++ b/scripts/test-e2e-orchestrator.mjs
@@ -21,7 +21,6 @@ const sharedEnv = {
   GCLOUD_PROJECT: 'demo-saikaku',
   MOCK_ANTHROPIC: '1',
   NODE_ENV: 'test',
-  TEST_BYPASS_AUTH: '1',
 };
 
 function log(message) {

--- a/scripts/test-e2e-orchestrator.mjs
+++ b/scripts/test-e2e-orchestrator.mjs
@@ -1,0 +1,149 @@
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import waitOn from 'wait-on';
+
+const ports = [3001, 5173, 8080, 9099];
+const children = [];
+let shuttingDown = false;
+
+const sharedEnv = {
+  ...process.env,
+  VITE_USE_FIREBASE_EMULATOR: 'true',
+  VITE_FIREBASE_PROJECT_ID: 'demo-saikaku',
+  VITE_FIREBASE_API_KEY: 'fake-api-key',
+  VITE_FIREBASE_AUTH_DOMAIN: 'demo-saikaku.firebaseapp.com',
+  VITE_FIREBASE_STORAGE_BUCKET: 'demo-saikaku.appspot.com',
+  VITE_FIREBASE_MESSAGING_SENDER_ID: '000000000000',
+  VITE_FIREBASE_APP_ID: '1:000000000000:web:test',
+  FIRESTORE_EMULATOR_HOST: 'localhost:8080',
+  FIREBASE_AUTH_EMULATOR_HOST: 'localhost:9099',
+  FIREBASE_PROJECT_ID: 'demo-saikaku',
+  MOCK_ANTHROPIC: '1',
+};
+
+function log(message) {
+  console.log(`[orchestrator] ${message}`);
+}
+
+function assertPortFree(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', () => {
+      reject(new Error(`port ${port} is already in use. Stop the process on ${port} before running E2E tests.`));
+    });
+    server.once('listening', () => {
+      server.close(() => resolve());
+    });
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+function prefixStream(stream, prefix) {
+  let buffer = '';
+  stream.on('data', (chunk) => {
+    buffer += chunk.toString();
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      if (line.length) console.log(`${prefix} ${line}`);
+    }
+  });
+  stream.on('end', () => {
+    if (buffer.length) console.log(`${prefix} ${buffer}`);
+  });
+}
+
+function run(name, command, args, env = sharedEnv) {
+  const child = spawn(command, args, {
+    cwd: process.cwd(),
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  children.push(child);
+  prefixStream(child.stdout, `[${name}]`);
+  prefixStream(child.stderr, `[${name}]`);
+  child.on('exit', (code, signal) => {
+    if (!shuttingDown && code !== 0) {
+      log(`${name} exited unexpectedly (code=${code}, signal=${signal ?? 'none'})`);
+    }
+  });
+  return child;
+}
+
+async function wait(resources, timeout) {
+  await waitOn({
+    resources,
+    timeout,
+    interval: 500,
+    tcpTimeout: 1000,
+    window: 1000,
+  });
+}
+
+async function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log('stopping spawned processes');
+  for (const child of children.slice().reverse()) {
+    if (child.exitCode === null && !child.killed) {
+      child.kill('SIGTERM');
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  for (const child of children.slice().reverse()) {
+    if (child.exitCode === null && !child.killed) {
+      child.kill('SIGKILL');
+    }
+  }
+}
+
+async function main() {
+  for (const port of ports) {
+    await assertPortFree(port);
+  }
+
+  log('starting Firebase emulators');
+  run('emulator', 'firebase', ['emulators:start', '--only', 'auth,firestore', '--project', 'demo-saikaku'], sharedEnv);
+  await wait(['tcp:9099', 'tcp:8080'], 60_000);
+
+  log('starting API server');
+  run('api', 'node', ['server.js'], sharedEnv);
+  await wait(['http://localhost:3001/api/health'], 30_000);
+
+  log('starting Vite dev server');
+  run('vite', 'npm', ['run', 'dev', '--', '--port', '5173', '--strictPort'], sharedEnv);
+  await wait(['http://localhost:5173'], 60_000);
+
+  log('running Playwright');
+  const playwright = spawn('npx', ['playwright', 'test'], {
+    cwd: process.cwd(),
+    env: sharedEnv,
+    stdio: 'inherit',
+  });
+
+  const code = await new Promise((resolve) => {
+    playwright.on('exit', (exitCode, signal) => {
+      if (signal) resolve(1);
+      else resolve(exitCode ?? 1);
+    });
+  });
+
+  await cleanup();
+  process.exit(code);
+}
+
+process.on('SIGINT', async () => {
+  await cleanup();
+  process.exit(130);
+});
+
+process.on('SIGTERM', async () => {
+  await cleanup();
+  process.exit(143);
+});
+
+main().catch(async (e) => {
+  console.error(`[orchestrator] ${e.message || e}`);
+  await cleanup();
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -6,7 +6,9 @@
  * → http://localhost:3001 でAPIが起動
  * → Vite dev server (localhost:5173) が /api/* をここにプロキシする
  */
-import 'dotenv/config';
+import dotenv from 'dotenv';
+dotenv.config({ path: '.env.local' });
+dotenv.config(); // .env もフォールバックで読む
 import express from 'express';
 import { createRequire } from 'module';
 
@@ -36,6 +38,10 @@ try {
 }
 
 // APIルート
+app.get('/api/health', (_req, res) => {
+  res.json({ ok: true, mode: process.env.MOCK_ANTHROPIC === '1' ? 'mock' : 'live' });
+});
+
 app.all('/api/analyze', (req, res) => {
   const handler = analyzeHandler.default || analyzeHandler;
   return handler(req, res);

--- a/server.js
+++ b/server.js
@@ -1,66 +1,6 @@
-/**
- * ローカル開発用APIサーバー
- * Vercelサーバーレス関数をローカルで動かすためのExpressラッパー
- *
- * 起動方法: node server.js
- * → http://localhost:3001 でAPIが起動
- * → Vite dev server (localhost:5173) が /api/* をここにプロキシする
- */
-import dotenv from 'dotenv';
-dotenv.config({ path: '.env.local' });
-dotenv.config(); // .env もフォールバックで読む
-import express from 'express';
-import { createRequire } from 'module';
+import app from './api/_app.js';
 
-const app = express();
-app.use(express.json({ limit: '10mb' }));
-
-// Vercelサーバーレス関数をExpressハンドラとして読み込む
-const analyzeHandler = await import('./api/analyze.js');
-const uaamHandler = await import('./api/uaam.js');
-
-// adminディレクトリのハンドラも読み込む（存在する場合）
-let adminHandlers = {};
-try {
-  const fs = await import('fs');
-  const path = await import('path');
-  const adminDir = path.resolve('./api/admin');
-  if (fs.existsSync(adminDir)) {
-    const files = fs.readdirSync(adminDir).filter(f => f.endsWith('.js'));
-    for (const file of files) {
-      const name = file.replace('.js', '');
-      const mod = await import(`./api/admin/${file}`);
-      adminHandlers[name] = mod.default || mod;
-    }
-  }
-} catch (e) {
-  console.log('⚠ admin handlers not loaded:', e.message);
-}
-
-// APIルート
-app.get('/api/health', (_req, res) => {
-  res.json({ ok: true, mode: process.env.MOCK_ANTHROPIC === '1' ? 'mock' : 'live' });
-});
-
-app.all('/api/analyze', (req, res) => {
-  const handler = analyzeHandler.default || analyzeHandler;
-  return handler(req, res);
-});
-
-app.all('/api/uaam', (req, res) => {
-  const handler = uaamHandler.default || uaamHandler;
-  return handler(req, res);
-});
-
-// adminルート
-for (const [name, handler] of Object.entries(adminHandlers)) {
-  app.all(`/api/admin/${name}`, (req, res) => handler(req, res));
-}
-
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.log(`\n✅ ローカルAPIサーバー起動: http://localhost:${PORT}`);
-  console.log('   /api/analyze  → 才覚領域分析');
-  console.log('   /api/uaam     → 才覚発動領域診断');
-  console.log(`\n💡 別ターミナルで npm run dev を実行して http://localhost:5173 にアクセス\n`);
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import LoadingScreen from './screens/LoadingScreen';
 import ResultScreen from './screens/ResultScreen';
 import AdminScreen from './screens/AdminScreen';
 import SelectScreen from './screens/SelectScreen';
+import HistoryScreen from './screens/HistoryScreen';
 import UAAMScreen from './screens/uaam/UAAMScreen';
 import UAAMLoadingScreen from './screens/uaam/UAAMLoadingScreen';
 import UAAMResultScreen from './screens/uaam/UAAMResultScreen';
@@ -100,6 +101,8 @@ export default function App() {
     return null;
   });
   const [uaamError, setUaamError] = useState('');
+  const [selectedAttempt, setSelectedAttempt] = useState(null);
+  const [selectedAttemptKind, setSelectedAttemptKind] = useState(null);
 
   useEffect(() => {
     if (devMode) return;
@@ -155,6 +158,8 @@ export default function App() {
   const handleSubmit = async (formData) => {
     setError('');
     setResult(null);
+    setSelectedAttempt(null);
+    setSelectedAttemptKind(null);
     setScreen('loading');
     try {
       if (!auth.currentUser) {
@@ -195,6 +200,8 @@ export default function App() {
   const handleUaamSubmit = async (answers, vAnswers = {}) => {
     setUaamError('');
     setUaamResult(null);
+    setSelectedAttempt(null);
+    setSelectedAttemptKind(null);
     setScreen('uaam-loading');
     try {
       if (!auth.currentUser) {
@@ -233,6 +240,8 @@ export default function App() {
 
   // 開発テスト用：ダミーデータで結果画面に直接遷移
   const handleUaamTestResult = () => {
+    setSelectedAttempt(null);
+    setSelectedAttemptKind(null);
     const dummyAnswers = {};
     for (let i = 1; i <= 48; i++) {
       dummyAnswers[i] = Math.floor(Math.random() * 5) + 1;
@@ -261,7 +270,20 @@ export default function App() {
     setUser(null);
     setResult(null);
     setUaamResult(null);
+    setSelectedAttempt(null);
+    setSelectedAttemptKind(null);
     setScreen('login');
+  };
+
+  const handleSelectHistory = (kind) => {
+    setSelectedAttempt(null);
+    setSelectedAttemptKind(null);
+    setScreen(kind === 'uaam' ? 'history-uaam' : 'history-saikaku');
+  };
+
+  const clearSelectedAttempt = () => {
+    setSelectedAttempt(null);
+    setSelectedAttemptKind(null);
   };
 
   // 管理者スコア復元：APIレスポンスのスコアでReact stateを直接更新（リロード不要）
@@ -331,13 +353,39 @@ export default function App() {
     return <UAAMLoadingScreen />;
   }
 
-  if (screen === 'uaam-result' && uaamResult) {
+  if (screen === 'history-saikaku' || screen === 'history-uaam') {
+    const kind = screen === 'history-uaam' ? 'uaam' : 'saikaku';
+    return (
+      <HistoryScreen
+        user={user}
+        kind={kind}
+        onBack={() => { clearSelectedAttempt(); setScreen('select'); }}
+        onSelectAttempt={(attempt) => {
+          setSelectedAttempt(attempt);
+          setSelectedAttemptKind(kind);
+          setScreen(kind === 'uaam' ? 'uaam-result' : 'result');
+        }}
+        onLogout={handleLogout}
+      />
+    );
+  }
+
+  if (screen === 'uaam-result' && (uaamResult || (selectedAttempt && selectedAttemptKind === 'uaam'))) {
     return (
       <UAAMResultScreen
         user={user}
         result={uaamResult}
+        attemptData={selectedAttemptKind === 'uaam' ? selectedAttempt : null}
         isAdmin={isAdmin}
-        onReset={() => { setUaamResult(null); setScreen('uaam'); }}
+        onReset={() => {
+          if (selectedAttemptKind === 'uaam') {
+            clearSelectedAttempt();
+            setScreen(uaamResult ? 'uaam-result' : 'uaam');
+            return;
+          }
+          setUaamResult(null);
+          setScreen('uaam');
+        }}
         onAdmin={() => setScreen('admin')}
         onLogout={handleLogout}
         onScoresRestored={handleScoresRestored}
@@ -349,14 +397,23 @@ export default function App() {
     return <LoadingScreen />;
   }
 
-  if (screen === 'result' && result) {
+  if (screen === 'result' && (result || (selectedAttempt && selectedAttemptKind === 'saikaku'))) {
     return (
       <ResultScreen
-        key={result.updatedAt || result.kakuchiiki || 'result'}
+        key={selectedAttemptKind === 'saikaku' ? selectedAttempt?.id : result.updatedAt || result.kakuchiiki || 'result'}
         user={user}
         result={result}
+        attemptData={selectedAttemptKind === 'saikaku' ? selectedAttempt : null}
         isAdmin={isAdmin}
-        onReset={() => { setResult(null); setScreen('select'); }}
+        onReset={() => {
+          if (selectedAttemptKind === 'saikaku') {
+            clearSelectedAttempt();
+            setScreen(result ? 'result' : 'select');
+            return;
+          }
+          setResult(null);
+          setScreen('select');
+        }}
         onAdmin={() => setScreen('admin')}
         onLogout={handleLogout}
       />
@@ -381,8 +438,9 @@ export default function App() {
     <SelectScreen
       user={user}
       isAdmin={isAdmin}
-      onSelectSaikaku={() => setScreen('input')}
-      onSelectUaam={() => setScreen('uaam')}
+      onSelectSaikaku={() => { clearSelectedAttempt(); setScreen('input'); }}
+      onSelectUaam={() => { clearSelectedAttempt(); setScreen('uaam'); }}
+      onSelectHistory={handleSelectHistory}
       onAdmin={() => setScreen('admin')}
       onLogout={handleLogout}
     />

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,6 +1,6 @@
 import { initializeApp } from 'firebase/app';
-import { getAuth, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut, createUserWithEmailAndPassword, signInWithEmailAndPassword, updateProfile, sendEmailVerification, sendPasswordResetEmail } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { getAuth, connectAuthEmulator, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut, createUserWithEmailAndPassword, signInWithEmailAndPassword, updateProfile, sendEmailVerification, sendPasswordResetEmail } from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -16,6 +16,12 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const googleProvider = new GoogleAuthProvider();
+
+if (import.meta.env.VITE_USE_FIREBASE_EMULATOR === 'true') {
+  connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
+  connectFirestoreEmulator(db, 'localhost', 8080);
+  console.log('[firebase] connected to local emulators (auth:9099, firestore:8080)');
+}
 
 export const signInWithGoogle = async () => {
   try {

--- a/src/hooks/useDiagnosisStatus.js
+++ b/src/hooks/useDiagnosisStatus.js
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function useDiagnosisStatus(user) {
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setStatus(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    let saikakuReady = false;
+    let uaamReady = false;
+    let saikakuErrored = false;
+    let uaamErrored = false;
+    let latestStatus = {};
+
+    const computeFromDoc = (snap, kind) => {
+      if (!snap?.exists()) return { attemptCount: 0, hasResult: false };
+      const data = snap.data() || {};
+      const hasResult = kind === 'saikaku'
+        ? !!data.result || !!data.analysis
+        : !!data.scores || !!data.analysis;
+      const rawCount = data.attemptCount ?? 0;
+
+      return {
+        attemptCount: Math.max(rawCount, hasResult ? 1 : 0),
+        hasResult,
+      };
+    };
+
+    const setKindStatus = (kind, nextStatus, errored = false) => {
+      if (cancelled) return;
+      if (kind === 'saikaku') {
+        saikakuReady = true;
+        saikakuErrored = errored;
+      }
+      if (kind === 'uaam') {
+        uaamReady = true;
+        uaamErrored = errored;
+      }
+      latestStatus = { ...latestStatus, [kind]: nextStatus };
+
+      if (!saikakuReady || !uaamReady || (saikakuErrored && uaamErrored)) {
+        setStatus(null);
+        return;
+      }
+
+      setStatus(latestStatus);
+    };
+
+    const unsubSaikaku = onSnapshot(
+      doc(db, 'results', user.uid),
+      (snap) => setKindStatus('saikaku', computeFromDoc(snap, 'saikaku')),
+      () => setKindStatus('saikaku', { attemptCount: 0, hasResult: false }, true),
+    );
+
+    const unsubUaam = onSnapshot(
+      doc(db, 'uaam_results', user.uid),
+      (snap) => setKindStatus('uaam', computeFromDoc(snap, 'uaam')),
+      () => setKindStatus('uaam', { attemptCount: 0, hasResult: false }, true),
+    );
+
+    return () => {
+      cancelled = true;
+      unsubSaikaku();
+      unsubUaam();
+    };
+  }, [user?.uid]);
+
+  return status;
+}

--- a/src/screens/HistoryScreen.jsx
+++ b/src/screens/HistoryScreen.jsx
@@ -1,0 +1,350 @@
+import { useEffect, useState } from 'react';
+import { collection, doc, getDoc, getDocs, orderBy, query } from 'firebase/firestore';
+import { db, signOutUser } from '../firebase';
+import { legacyDocToAttempt } from '../utils/attemptAdapter';
+
+const TOKENS = {
+  saikaku: {
+    title: '才覚領域',
+    subtitle: 'Architecture History',
+    accent: '#C4922A',
+    light: '#E8C47A',
+    border: 'rgba(196,146,42,0.22)',
+    soft: 'rgba(196,146,42,0.09)',
+  },
+  uaam: {
+    title: '才覚発動領域 MATRIX',
+    subtitle: 'Activation Matrix History',
+    accent: '#4A6FA5',
+    light: '#8FB4E0',
+    border: 'rgba(74,111,165,0.24)',
+    soft: 'rgba(74,111,165,0.10)',
+  },
+};
+
+function formatDate(value) {
+  if (!value) return '日付未設定';
+  const date = typeof value.toDate === 'function' ? value.toDate() : new Date(value);
+  if (Number.isNaN(date.getTime())) return '日付未設定';
+
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function getAttemptDate(attempt) {
+  return attempt.summary?.createdAt ?? attempt.createdAt ?? null;
+}
+
+function getAttemptLabel(attempt, kind) {
+  if (kind === 'uaam') {
+    return attempt.summary?.typeName
+      ?? attempt.full?.analysis?.type_name
+      ?? attempt.full?.analysis?.primary_type
+      ?? 'MATRIX 診断結果';
+  }
+
+  return attempt.summary?.kakuchiiki
+    ?? attempt.full?.selectedKakuchiiki
+    ?? attempt.full?.result?.kakuchiiki
+    ?? '才覚領域 診断結果';
+}
+
+function getAttemptOrdinal(attempt, index, total) {
+  if (attempt.isLegacy) return '保存済み履歴';
+  return `${total - index}回目`;
+}
+
+export default function HistoryScreen({ user, kind, onBack, onSelectAttempt, onLogout }) {
+  const [attempts, setAttempts] = useState(null);
+  const [error, setError] = useState('');
+  const [hoveredId, setHoveredId] = useState('');
+  const tokens = TOKENS[kind] ?? TOKENS.saikaku;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      if (!user?.uid) {
+        setAttempts([]);
+        return;
+      }
+
+      setAttempts(null);
+      setError('');
+
+      try {
+        const collName = kind === 'uaam' ? 'uaam_results' : 'results';
+        const parentRef = doc(db, collName, user.uid);
+        const subSnap = await getDocs(query(collection(parentRef, 'attempts'), orderBy('createdAt', 'desc')));
+        const list = subSnap.docs
+          .map((d) => ({ id: d.id, ...d.data() }))
+          .filter((attempt) => attempt.status === 'committed');
+
+        if (list.length === 0) {
+          const parentSnap = await getDoc(parentRef);
+          const synth = legacyDocToAttempt(parentSnap.exists() ? parentSnap.data() : null, kind);
+          if (synth) list.push(synth);
+        }
+
+        if (!cancelled) setAttempts(list);
+      } catch (e) {
+        if (!cancelled) {
+          setError(e.message || '履歴の読み込みに失敗しました');
+          setAttempts([]);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.uid, kind]);
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: 'linear-gradient(160deg, #0D0B09 0%, #1A1610 42%, #0D0B09 100%)',
+      position: 'relative',
+      overflow: 'hidden',
+    }}>
+      <div style={{
+        position: 'absolute', top: -120, right: -120,
+        width: 400, height: 400, borderRadius: '50%',
+        background: `radial-gradient(circle, ${tokens.soft} 0%, transparent 70%)`,
+        pointerEvents: 'none',
+      }} />
+      <div style={{
+        position: 'absolute', bottom: -100, left: -100,
+        width: 340, height: 340, borderRadius: '50%',
+        background: 'radial-gradient(circle, rgba(255,255,255,0.035) 0%, transparent 70%)',
+        pointerEvents: 'none',
+      }} />
+
+      <div style={{
+        background: 'rgba(13,11,9,0.6)',
+        backdropFilter: 'blur(20px)',
+        WebkitBackdropFilter: 'blur(20px)',
+        borderBottom: `1px solid ${tokens.border}`,
+        padding: '14px 24px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        position: 'relative',
+        zIndex: 1,
+      }}>
+        <button onClick={onBack} style={{
+          fontSize: 12,
+          color: tokens.light,
+          background: tokens.soft,
+          border: `1px solid ${tokens.border}`,
+          borderRadius: 8,
+          padding: '7px 13px',
+          cursor: 'pointer',
+          fontWeight: 700,
+          letterSpacing: '0.04em',
+        }}>
+          ← 戻る
+        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          {user?.photoURL && (
+            <img src={user.photoURL} alt="" style={{
+              width: 30, height: 30, borderRadius: '50%',
+              border: `2px solid ${tokens.border}`,
+            }} />
+          )}
+          <span style={{ fontSize: 12, color: '#FFFFFF', fontWeight: 600 }}>{user?.displayName}</span>
+          <button onClick={async () => { await signOutUser(); onLogout(); }} style={{
+            fontSize: 11,
+            color: '#8A8070',
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: 6,
+            padding: '5px 12px',
+            cursor: 'pointer',
+            fontWeight: 500,
+          }}>
+            ログアウト
+          </button>
+        </div>
+      </div>
+
+      <main style={{
+        maxWidth: 640,
+        margin: '0 auto',
+        padding: '52px 20px 72px',
+        position: 'relative',
+        zIndex: 1,
+      }}>
+        <div style={{ textAlign: 'center', marginBottom: 32 }}>
+          <div style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            background: tokens.soft,
+            border: `1px solid ${tokens.border}`,
+            borderRadius: 100,
+            padding: '5px 16px',
+            marginBottom: 16,
+          }}>
+            <span style={{
+              fontSize: 10,
+              fontWeight: 800,
+              letterSpacing: '0.18em',
+              color: tokens.light,
+              textTransform: 'uppercase',
+            }}>
+              History
+            </span>
+          </div>
+          <h1 style={{
+            fontSize: 28,
+            fontWeight: 800,
+            color: '#F5F0E8',
+            margin: 0,
+            fontFamily: "'Noto Serif JP', Georgia, serif",
+            letterSpacing: '0.07em',
+          }}>
+            {tokens.title}
+          </h1>
+          <p style={{
+            fontSize: 12,
+            color: tokens.light,
+            margin: '10px 0 0',
+            letterSpacing: '0.14em',
+            fontWeight: 700,
+          }}>
+            {tokens.subtitle}
+          </p>
+        </div>
+
+        {attempts === null && (
+          <div style={{
+            border: `1px solid ${tokens.border}`,
+            background: 'rgba(26,22,16,0.72)',
+            borderRadius: 16,
+            padding: '36px 24px',
+            textAlign: 'center',
+            color: '#8A8070',
+            fontSize: 13,
+          }}>
+            読み込み中...
+          </div>
+        )}
+
+        {attempts !== null && attempts.length === 0 && (
+          <div style={{
+            border: `1px solid ${tokens.border}`,
+            background: 'rgba(26,22,16,0.72)',
+            borderRadius: 16,
+            padding: '36px 24px',
+            textAlign: 'center',
+          }}>
+            <p style={{ color: '#F5F0E8', fontSize: 15, fontWeight: 700, margin: '0 0 8px' }}>
+              まだ診断履歴がありません
+            </p>
+            {error && (
+              <p style={{ color: '#8A8070', fontSize: 12, margin: 0, lineHeight: 1.7 }}>
+                {error}
+              </p>
+            )}
+          </div>
+        )}
+
+        {attempts !== null && attempts.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            {attempts.map((attempt, index) => {
+              const isHovered = hoveredId === attempt.id;
+              const label = getAttemptLabel(attempt, kind);
+              const ordinal = getAttemptOrdinal(attempt, index, attempts.length);
+
+              return (
+                <button
+                  key={attempt.id}
+                  onClick={() => onSelectAttempt(attempt)}
+                  onMouseEnter={() => setHoveredId(attempt.id)}
+                  onMouseLeave={() => setHoveredId('')}
+                  style={{
+                    width: '100%',
+                    textAlign: 'left',
+                    border: `1px solid ${isHovered ? tokens.light : tokens.border}`,
+                    borderRadius: 16,
+                    background: isHovered
+                      ? `linear-gradient(145deg, ${tokens.soft} 0%, rgba(26,22,16,0.96) 100%)`
+                      : 'rgba(26,22,16,0.78)',
+                    padding: '22px 22px 20px',
+                    cursor: 'pointer',
+                    position: 'relative',
+                    overflow: 'hidden',
+                    boxShadow: isHovered ? `0 18px 52px ${tokens.soft}` : '0 4px 24px rgba(0,0,0,0.28)',
+                    transform: isHovered ? 'translateY(-2px)' : 'translateY(0)',
+                    transition: 'all 0.28s ease',
+                  }}
+                >
+                  <div style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: 2,
+                    background: `linear-gradient(90deg, transparent 8%, ${tokens.accent} 50%, transparent 92%)`,
+                    opacity: isHovered ? 0.9 : 0.45,
+                  }} />
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 12 }}>
+                    <span style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      background: tokens.soft,
+                      border: `1px solid ${tokens.border}`,
+                      borderRadius: 100,
+                      padding: '4px 11px',
+                      color: tokens.light,
+                      fontSize: 10,
+                      fontWeight: 800,
+                      letterSpacing: '0.12em',
+                    }}>
+                      {ordinal}
+                    </span>
+                    <span style={{
+                      color: '#8A8070',
+                      fontSize: 11,
+                      fontWeight: 600,
+                      whiteSpace: 'nowrap',
+                      paddingTop: 4,
+                    }}>
+                      {formatDate(getAttemptDate(attempt))}
+                    </span>
+                  </div>
+                  <div style={{
+                    fontFamily: "'Noto Serif JP', Georgia, serif",
+                    color: '#FFFFFF',
+                    fontSize: 21,
+                    fontWeight: 800,
+                    lineHeight: 1.5,
+                    letterSpacing: '0.04em',
+                    wordBreak: 'break-word',
+                  }}>
+                    {label}
+                  </div>
+                  <div style={{
+                    marginTop: 14,
+                    color: tokens.light,
+                    fontSize: 12,
+                    fontWeight: 700,
+                    letterSpacing: '0.06em',
+                  }}>
+                    結果を見る →
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/screens/HistoryScreen.jsx
+++ b/src/screens/HistoryScreen.jsx
@@ -264,6 +264,7 @@ export default function HistoryScreen({ user, kind, onBack, onSelectAttempt, onL
 
               return (
                 <button
+                  data-testid="history-item"
                   key={attempt.id}
                   onClick={() => onSelectAttempt(attempt)}
                   onMouseEnter={() => setHoveredId(attempt.id)}

--- a/src/screens/ResultScreen.jsx
+++ b/src/screens/ResultScreen.jsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { doc, setDoc } from 'firebase/firestore';
 import { db, signOutUser } from '../firebase';
 import { computePcts, CHART_COLORS } from '../utils/chartUtils';
+import { attemptToResultProps } from '../utils/attemptAdapter';
 
 const COLORS = {
   ...CHART_COLORS,
@@ -281,14 +282,29 @@ function CategorySection({ title, type, axes }) {
 }
 
 // ── メインコンポーネント ─────────────────────────────────────────────────
-export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, onLogout }) {
-  const [selected, setSelected] = useState(result.kakuchiiki || result.kakuchiiki_options?.[0] || '');
+export default function ResultScreen({ user, result, attemptData, isAdmin, onReset, onAdmin, onLogout }) {
+  const attemptProps = useMemo(
+    () => (attemptData ? attemptToResultProps(attemptData, 'saikaku') : null),
+    [attemptData],
+  );
+  const effectiveResult = attemptProps?.result ?? result;
+  const isHistoryView = !!attemptData;
+  const initialSelected = effectiveResult?.selectedKakuchiiki
+    || effectiveResult?.kakuchiiki
+    || effectiveResult?.kakuchiiki_options?.[0]
+    || '';
+  const [selected, setSelected] = useState(initialSelected);
   const [saving,   setSaving]   = useState(false);
   const [copied,   setCopied]   = useState(false);
   const [hoverPdf, setHoverPdf] = useState(false);
   const [hoverShare, setHoverShare] = useState(false);
 
+  useEffect(() => {
+    setSelected(initialSelected);
+  }, [initialSelected]);
+
   const handleSelectKakuchiiki = async (option) => {
+    if (isHistoryView) return;
     if (option === selected) return;
     setSelected(option);
     setSaving(true);
@@ -304,7 +320,7 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
   const handlePdfDownload = () => { window.print(); };
 
   const handleShare = async () => {
-    const text = `${result.name || user.displayName}の才覚領域：${selected}`;
+    const text = `${effectiveResult?.name || user.displayName}の才覚領域：${selected}`;
     try {
       if (navigator.share) {
         await navigator.share({ title: 'Unique Ability Architecture', text });
@@ -315,6 +331,36 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
       }
     } catch (e) { /* user cancelled */ }
   };
+
+  if (!effectiveResult) {
+    return (
+      <div style={{
+        minHeight: '100vh',
+        background: 'linear-gradient(170deg, #0A0908 0%, #14110D 50%, #0D0B09 100%)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+      }}>
+        <div style={{ textAlign: 'center' }}>
+          <p style={{ color: '#F5F0E8', fontSize: 15, fontWeight: 700, margin: '0 0 16px' }}>
+            結果データを表示できませんでした
+          </p>
+          <button onClick={onReset} style={{
+            border: '1px solid rgba(196,146,42,0.25)',
+            background: 'rgba(196,146,42,0.08)',
+            color: '#C4922A',
+            borderRadius: 10,
+            padding: '10px 18px',
+            cursor: 'pointer',
+            fontWeight: 700,
+          }}>
+            戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={{
@@ -406,8 +452,28 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
               margin: '0 0 8px',
               letterSpacing: '0.05em',
             }}>
-              {result.name || user.displayName}
+              {effectiveResult.name || user.displayName}
             </h1>
+
+            {isHistoryView && (
+              <button
+                onClick={onReset}
+                style={{
+                  marginTop: 16,
+                  border: 'none',
+                  background: 'transparent',
+                  color: '#C4922A',
+                  fontSize: 12,
+                  fontWeight: 700,
+                  letterSpacing: '0.06em',
+                  cursor: 'pointer',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 4,
+                }}
+              >
+                最新の結果に戻る
+              </button>
+            )}
 
             {/* 装飾ライン */}
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12, margin: '16px 0' }}>
@@ -466,14 +532,15 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
               className="pdf-pattern-grid"
               style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16 }}
             >
-              {(result.kakuchiiki_options || [result.kakuchiiki]).map((option, i) => {
+              {(effectiveResult.kakuchiiki_options || [effectiveResult.kakuchiiki]).map((option, i) => {
                 const isSelected    = selected === option;
-                const isRecommended = option === result.kakuchiiki;
+                const isRecommended = option === effectiveResult.kakuchiiki;
                 return (
                   <button
                     key={i}
                     className="pdf-pattern-card"
                     onClick={() => handleSelectKakuchiiki(option)}
+                    disabled={isHistoryView}
                     style={{
                       padding: '20px 24px',
                       borderRadius: 14,
@@ -482,7 +549,7 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
                         ? 'linear-gradient(135deg, rgba(196,146,42,0.12), rgba(196,146,42,0.06))'
                         : 'rgba(255,255,255,0.02)',
                       boxShadow: isSelected ? '0 4px 24px rgba(196,146,42,0.2), inset 0 1px 0 rgba(196,146,42,0.1)' : 'none',
-                      cursor: 'pointer',
+                      cursor: isHistoryView ? 'default' : 'pointer',
                       textAlign: 'left',
                       position: 'relative',
                       transition: 'all 0.3s ease',
@@ -494,6 +561,7 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
                       WebkitAppearance: 'none',
                       appearance: 'none',
                       outline: 'none',
+                      opacity: 1,
                     }}
                   >
                     {isRecommended && (
@@ -511,7 +579,7 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
                 );
               })}
             </div>
-            {saving && <p style={{ textAlign: 'center', fontSize: 12, color: '#8A8070', marginTop: 12 }}>保存中...</p>}
+            {saving && !isHistoryView && <p style={{ textAlign: 'center', fontSize: 12, color: '#8A8070', marginTop: 12 }}>保存中...</p>}
           </div>
 
           {/* 3列グリッド：価値観・才能・情熱（スクリーンのみ） */}
@@ -519,13 +587,13 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
             className="no-print"
             style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 20, marginBottom: 32 }}
           >
-            <CategorySection title="価値観" type="value"   axes={result.value}   />
-            <CategorySection title="才能"   type="talent"  axes={result.talent}  />
-            <CategorySection title="情熱"   type="passion" axes={result.passion} />
+            <CategorySection title="価値観" type="value"   axes={effectiveResult.value}   />
+            <CategorySection title="才能"   type="talent"  axes={effectiveResult.talent}  />
+            <CategorySection title="情熱"   type="passion" axes={effectiveResult.passion} />
           </div>
 
           {/* WHAT セクション（スクリーンのみ） */}
-          {result.what && (
+          {effectiveResult.what && (
             <div
               className="no-print"
               style={{
@@ -548,11 +616,11 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
                   <span style={{ fontSize: 13, color: '#6A6050', marginLeft: 10 }}>才覚領域から自然に生まれること</span>
                 </div>
               </div>
-              {result.what.products?.length > 0 && (
+              {effectiveResult.what.products?.length > 0 && (
                 <div style={{ marginBottom: 20 }}>
                   <p style={{ fontSize: 14, color: '#C8C0B0', margin: '0 0 10px', fontWeight: 700, letterSpacing: '0.05em' }}>具体的なサービス・活動</p>
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                    {result.what.products.map((p, i) => (
+                    {effectiveResult.what.products.map((p, i) => (
                       <span key={i} style={{ padding: '4px 14px', borderRadius: 100, background: 'rgba(196,146,42,0.1)', border: '1px solid rgba(196,146,42,0.3)', color: '#F5F0E8', fontSize: 12, fontWeight: 500 }}>
                         {p}
                       </span>
@@ -562,16 +630,16 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
               )}
               <div style={{ height: 1, background: 'rgba(196,146,42,0.1)', margin: '0 0 16px' }} />
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 12 }}>
-                {result.what.actions && (
+                {effectiveResult.what.actions && (
                   <div style={{ background: 'rgba(196,146,42,0.06)', border: '1px solid rgba(196,146,42,0.12)', borderLeft: '3px solid #FFD700', borderRadius: 12, padding: '14px 18px' }}>
                     <p style={{ fontFamily: "'Playfair Display', Georgia, serif", fontSize: 15, fontWeight: 800, color: '#FFD700', letterSpacing: '0.1em', margin: '0 0 8px' }}>First Step</p>
-                    <p style={{ fontSize: 14, color: '#C8C0B0', margin: 0, lineHeight: 1.8 }}>{result.what.actions}</p>
+                    <p style={{ fontSize: 14, color: '#C8C0B0', margin: 0, lineHeight: 1.8 }}>{effectiveResult.what.actions}</p>
                   </div>
                 )}
-                {result.what.offer && (
+                {effectiveResult.what.offer && (
                   <div style={{ background: 'rgba(196,146,42,0.06)', border: '1px solid rgba(196,146,42,0.12)', borderLeft: '3px solid #FFD700', borderRadius: 12, padding: '14px 18px' }}>
                     <p style={{ fontFamily: "'Playfair Display', Georgia, serif", fontSize: 15, fontWeight: 800, color: '#FFD700', letterSpacing: '0.1em', margin: '0 0 8px' }}>To the World</p>
-                    <p style={{ fontSize: 14, color: '#C8C0B0', margin: 0, lineHeight: 1.8 }}>{result.what.offer}</p>
+                    <p style={{ fontSize: 14, color: '#C8C0B0', margin: 0, lineHeight: 1.8 }}>{effectiveResult.what.offer}</p>
                   </div>
                 )}
               </div>
@@ -579,7 +647,7 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
           )}
 
           {/* REWARD セクション（スクリーンのみ） */}
-          {result.reward && (
+          {effectiveResult.reward && (
             <div
               className="no-print"
               style={{
@@ -606,19 +674,19 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
                   { key: 'social',    label: '社会', icon: '🌍', color: '#7AA8D0' },
                   { key: 'intrinsic', label: '内的', icon: '✨', color: '#A090D8' },
                 ].map(({ key, label, icon, color }) =>
-                  result.reward[key] ? (
+                  effectiveResult.reward[key] ? (
                     <div key={key} style={{ background: `${color}0A`, border: `1px solid ${color}18`, borderLeft: `3px solid ${color}60`, borderRadius: 12, padding: '14px 16px', overflow: 'hidden', wordBreak: 'break-all', whiteSpace: 'normal' }}>
                       <p style={{ fontSize: 18, fontWeight: 800, color, margin: '0 0 8px', letterSpacing: '0.08em' }}>{icon} {label}</p>
-                      <p style={{ fontSize: 13, color: '#A0988A', margin: 0, lineHeight: 1.8, overflow: 'hidden', wordBreak: 'break-all', whiteSpace: 'normal', display: '-webkit-box', WebkitLineClamp: 6, WebkitBoxOrient: 'vertical' }}>{result.reward[key]}</p>
+                      <p style={{ fontSize: 13, color: '#A0988A', margin: 0, lineHeight: 1.8, overflow: 'hidden', wordBreak: 'break-all', whiteSpace: 'normal', display: '-webkit-box', WebkitLineClamp: 6, WebkitBoxOrient: 'vertical' }}>{effectiveResult.reward[key]}</p>
                     </div>
                   ) : null
                 )}
               </div>
-              {result.reward.model && (
+              {effectiveResult.reward.model && (
                 <div style={{ background: 'rgba(62,207,190,0.06)', border: '1px solid rgba(62,207,190,0.15)', borderRadius: 14, padding: '18px 22px' }}>
                   <p style={{ fontFamily: "'Playfair Display', Georgia, serif", fontSize: 20, fontWeight: 900, color: '#3ECFBE', letterSpacing: '0.15em', margin: '0 0 10px' }}>Reward Model</p>
                   <p style={{ fontSize: 15, color: '#D0C8B8', margin: 0, lineHeight: 1.9, fontFamily: "'Noto Serif JP', Georgia, serif", fontWeight: 600, overflow: 'hidden', wordBreak: 'break-all', whiteSpace: 'normal', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
-                    {result.reward.model}
+                    {effectiveResult.reward.model}
                   </p>
                 </div>
               )}
@@ -654,9 +722,9 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
             </div>
             <div style={{ display: 'flex', justifyContent: 'space-around', width: '100%', boxSizing: 'border-box', marginBottom: 6 }}>
               {[
-                { tp: 'value',   label: '価値観', axesData: result.value   },
-                { tp: 'talent',  label: '才能',   axesData: result.talent  },
-                { tp: 'passion', label: '情熱',   axesData: result.passion },
+                { tp: 'value',   label: '価値観', axesData: effectiveResult.value   },
+                { tp: 'talent',  label: '才能',   axesData: effectiveResult.talent  },
+                { tp: 'passion', label: '情熱',   axesData: effectiveResult.passion },
               ].map(({ tp, label, axesData }) => {
                 const arr = ['axis1', 'axis2', 'axis3'].map(k => axesData?.[k]).filter(Boolean);
                 const dotColor = DONUT_COLORS[tp];
@@ -683,18 +751,18 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
               Narrative
             </div>
             <p style={{ fontSize: 11, color: '#D4C9B0', lineHeight: 1.55, margin: '0 0 5px', fontFamily: '-apple-system, BlinkMacSystemFont, Inter, sans-serif' }}>
-              {result.insight}
+              {effectiveResult.insight}
             </p>
-            {result.what && (
+            {effectiveResult.what && (
               <>
                 <div style={{ height: 1, background: '#FDFCFA10', margin: '0 0 5px' }} />
-                {result.what.products?.length > 0 && (
+                {effectiveResult.what.products?.length > 0 && (
                   <div style={{ marginBottom: 4 }}>
                     <p style={{ fontSize: 12, fontWeight: 800, color: '#FFD700', letterSpacing: '0.08em', margin: '0 0 3px' }}>
                       ▶ What — 自然に生まれること
                     </p>
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 3 }}>
-                      {result.what.products.map((p, i) => (
+                      {effectiveResult.what.products.map((p, i) => (
                         <span key={i} style={{ padding: '1px 8px', borderRadius: 100, background: '#C4922A22', border: '1px solid rgba(255,255,255,0.3)', color: '#ffffff', fontSize: 10, fontWeight: 600 }}>
                           {p}
                         </span>
@@ -702,22 +770,22 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
                     </div>
                   </div>
                 )}
-                {result.what.actions && (
+                {effectiveResult.what.actions && (
                   <p style={{ fontSize: 11, color: '#D4C9B0', margin: '0 0 3px', lineHeight: 1.5 }}>
                     <span style={{ color: '#FFD700', fontWeight: 800, fontSize: 12 }}>First Step：</span>
-                    {result.what.actions}
+                    {effectiveResult.what.actions}
                   </p>
                 )}
               </>
             )}
-            {result.reward?.model && (
+            {effectiveResult.reward?.model && (
               <>
                 <div style={{ height: 1, background: '#FDFCFA10', margin: '5px 0 4px' }} />
                 <p style={{ fontSize: 20, fontWeight: 900, color: '#3ECFBE', letterSpacing: '0.12em', margin: '0 0 2px' }}>
                   ▶ Reward Model
                 </p>
                 <p style={{ fontSize: 11, color: '#F0EAE0', margin: 0, lineHeight: 1.55, fontFamily: '-apple-system, BlinkMacSystemFont, Inter, sans-serif', fontWeight: 600 }}>
-                  {result.reward.model}
+                  {effectiveResult.reward.model}
                 </p>
               </>
             )}
@@ -823,7 +891,7 @@ export default function ResultScreen({ user, result, isAdmin, onReset, onAdmin, 
             transition: 'all 0.3s ease',
           }}
         >
-          もう一度解析する
+          {isHistoryView ? '最新の結果に戻る' : 'もう一度解析する'}
         </button>
       </div>
 

--- a/src/screens/SelectScreen.jsx
+++ b/src/screens/SelectScreen.jsx
@@ -1,16 +1,40 @@
 import { useState } from 'react';
 import { signOutUser } from '../firebase';
+import useDiagnosisStatus from '../hooks/useDiagnosisStatus';
 
 const UAAM_PASS = 'kokusogaku';
 
-export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectUaam, onAdmin, onLogout }) {
+export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectUaam, onSelectHistory, onAdmin, onLogout }) {
   const [showPassModal, setShowPassModal] = useState(false);
   const [pass, setPass] = useState('');
   const [passError, setPassError] = useState('');
   const [hoverSaikaku, setHoverSaikaku] = useState(false);
   const [hoverUaam, setHoverUaam] = useState(false);
+  const [hoverSaikakuHistory, setHoverSaikakuHistory] = useState(false);
+  const [hoverUaamHistory, setHoverUaamHistory] = useState(false);
+  const status = useDiagnosisStatus(user);
+  const saikakuAttemptCount = status?.saikaku?.attemptCount ?? 0;
+  const uaamAttemptCount = status?.uaam?.attemptCount ?? 0;
+  const isSaikakuLimitReached = status !== null && saikakuAttemptCount >= 2;
+  const isUaamLimitReached = status !== null && uaamAttemptCount >= 2;
+
+  const showLimitAlert = () => {
+    alert('診断は最大2回まで実施済みです。履歴を確認する場合は「履歴を見る」からどうぞ。');
+  };
+
+  const handleSaikakuClick = () => {
+    if (isSaikakuLimitReached) {
+      showLimitAlert();
+      return;
+    }
+    onSelectSaikaku();
+  };
 
   const handleUaamClick = () => {
+    if (isUaamLimitReached) {
+      showLimitAlert();
+      return;
+    }
     setPass('');
     setPassError('');
     setShowPassModal(true);
@@ -23,6 +47,85 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
     } else {
       setPassError('パスワードが正しくありません');
     }
+  };
+
+  const getCardPadding = (count) => {
+    if (status === null || count <= 0) return '32px 28px';
+    return count >= 2 ? '32px 28px 78px' : '32px 28px 58px';
+  };
+
+  const renderBadge = (count, palette) => {
+    if (status === null || count <= 0) return null;
+    return (
+      <div style={{
+        position: 'absolute',
+        top: 18,
+        right: 18,
+        background: palette.background,
+        border: `1px solid ${palette.border}`,
+        color: palette.color,
+        fontSize: 10,
+        fontWeight: 800,
+        letterSpacing: '0.18em',
+        padding: '4px 10px',
+        borderRadius: 100,
+        zIndex: 2,
+      }}>
+        診断済み ({count}/2)
+      </div>
+    );
+  };
+
+  const renderHistoryArea = (kind, count, color, hover, setHover) => {
+    if (status === null || count <= 0) return null;
+    return (
+      <div style={{
+        position: 'absolute',
+        left: 28,
+        bottom: 24,
+        zIndex: 3,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 8,
+        pointerEvents: 'none',
+      }}>
+        {count >= 2 && (
+          <span style={{
+            color: '#8A8070',
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '0.04em',
+          }}>
+            診断は最大2回まで実施済み
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelectHistory(kind);
+          }}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+          style={{
+            border: 'none',
+            background: 'transparent',
+            padding: 0,
+            color,
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            cursor: 'pointer',
+            textDecoration: hover ? 'underline' : 'none',
+            textUnderlineOffset: 3,
+            pointerEvents: 'auto',
+          }}
+        >
+          履歴を見る ({count})
+        </button>
+      </div>
+    );
   };
 
   return (
@@ -114,36 +217,42 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
         </div>
 
         {/* ─── 才覚領域カード ─── */}
-        <button
-          onClick={onSelectSaikaku}
-          onMouseEnter={() => setHoverSaikaku(true)}
-          onMouseLeave={() => setHoverSaikaku(false)}
-          style={{
-            width: '100%',
-            background: hoverSaikaku
-              ? 'linear-gradient(145deg, rgba(196,146,42,0.12) 0%, rgba(26,22,16,0.95) 100%)'
-              : 'linear-gradient(145deg, rgba(196,146,42,0.06) 0%, rgba(26,22,16,0.9) 100%)',
-            border: `1px solid ${hoverSaikaku ? 'rgba(196,146,42,0.4)' : 'rgba(196,146,42,0.15)'}`,
-            borderRadius: 20, padding: 0, cursor: 'pointer',
-            textAlign: 'left',
-            transition: 'all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-            transform: hoverSaikaku ? 'translateY(-4px)' : 'translateY(0)',
-            boxShadow: hoverSaikaku
-              ? '0 20px 60px rgba(196,146,42,0.15), 0 0 0 1px rgba(196,146,42,0.1) inset'
-              : '0 4px 24px rgba(0,0,0,0.3)',
-            overflow: 'hidden',
-            position: 'relative',
-          }}
-        >
-          {/* ゴールドのアクセントライン */}
-          <div style={{
-            position: 'absolute', top: 0, left: 0, right: 0, height: 2,
-            background: 'linear-gradient(90deg, transparent 10%, #C4922A 50%, transparent 90%)',
-            opacity: hoverSaikaku ? 1 : 0.4,
-            transition: 'opacity 0.4s ease',
-          }} />
+        <div style={{ width: '100%', position: 'relative' }}>
+          <button
+            onClick={handleSaikakuClick}
+            onMouseEnter={() => setHoverSaikaku(true)}
+            onMouseLeave={() => setHoverSaikaku(false)}
+            style={{
+              width: '100%',
+              background: hoverSaikaku
+                ? 'linear-gradient(145deg, rgba(196,146,42,0.12) 0%, rgba(26,22,16,0.95) 100%)'
+                : 'linear-gradient(145deg, rgba(196,146,42,0.06) 0%, rgba(26,22,16,0.9) 100%)',
+              border: `1px solid ${hoverSaikaku ? 'rgba(196,146,42,0.4)' : 'rgba(196,146,42,0.15)'}`,
+              borderRadius: 20, padding: 0, cursor: 'pointer',
+              textAlign: 'left',
+              transition: 'all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+              transform: hoverSaikaku ? 'translateY(-4px)' : 'translateY(0)',
+              boxShadow: hoverSaikaku
+                ? '0 20px 60px rgba(196,146,42,0.15), 0 0 0 1px rgba(196,146,42,0.1) inset'
+                : '0 4px 24px rgba(0,0,0,0.3)',
+              overflow: 'hidden',
+              position: 'relative',
+            }}
+          >
+            {/* ゴールドのアクセントライン */}
+            <div style={{
+              position: 'absolute', top: 0, left: 0, right: 0, height: 2,
+              background: 'linear-gradient(90deg, transparent 10%, #C4922A 50%, transparent 90%)',
+              opacity: hoverSaikaku ? 1 : 0.4,
+              transition: 'opacity 0.4s ease',
+            }} />
+            {renderBadge(saikakuAttemptCount, {
+              background: 'rgba(196,146,42,0.18)',
+              border: 'rgba(196,146,42,0.45)',
+              color: '#E8C47A',
+            })}
 
-          <div style={{ padding: '32px 28px' }}>
+            <div style={{ padding: getCardPadding(saikakuAttemptCount) }}>
             {/* サブラベル */}
             <div style={{
               display: 'inline-flex', alignItems: 'center',
@@ -209,40 +318,48 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
                 }}>→</span>
               </div>
             </div>
-          </div>
-        </button>
+            </div>
+          </button>
+          {renderHistoryArea('saikaku', saikakuAttemptCount, '#E8C47A', hoverSaikakuHistory, setHoverSaikakuHistory)}
+        </div>
 
         {/* ─── 才覚発動領域カード ─── */}
-        <button
-          onClick={handleUaamClick}
-          onMouseEnter={() => setHoverUaam(true)}
-          onMouseLeave={() => setHoverUaam(false)}
-          style={{
-            width: '100%',
-            background: hoverUaam
-              ? 'linear-gradient(145deg, rgba(74,111,165,0.12) 0%, rgba(26,22,16,0.95) 100%)'
-              : 'linear-gradient(145deg, rgba(74,111,165,0.06) 0%, rgba(26,22,16,0.9) 100%)',
-            border: `1px solid ${hoverUaam ? 'rgba(74,111,165,0.4)' : 'rgba(74,111,165,0.15)'}`,
-            borderRadius: 20, padding: 0, cursor: 'pointer',
-            textAlign: 'left',
-            transition: 'all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-            transform: hoverUaam ? 'translateY(-4px)' : 'translateY(0)',
-            boxShadow: hoverUaam
-              ? '0 20px 60px rgba(74,111,165,0.15), 0 0 0 1px rgba(74,111,165,0.1) inset'
-              : '0 4px 24px rgba(0,0,0,0.3)',
-            overflow: 'hidden',
-            position: 'relative',
-          }}
-        >
-          {/* ブルーのアクセントライン */}
-          <div style={{
-            position: 'absolute', top: 0, left: 0, right: 0, height: 2,
-            background: 'linear-gradient(90deg, transparent 10%, #4A6FA5 50%, transparent 90%)',
-            opacity: hoverUaam ? 1 : 0.4,
-            transition: 'opacity 0.4s ease',
-          }} />
+        <div style={{ width: '100%', position: 'relative' }}>
+          <button
+            onClick={handleUaamClick}
+            onMouseEnter={() => setHoverUaam(true)}
+            onMouseLeave={() => setHoverUaam(false)}
+            style={{
+              width: '100%',
+              background: hoverUaam
+                ? 'linear-gradient(145deg, rgba(74,111,165,0.12) 0%, rgba(26,22,16,0.95) 100%)'
+                : 'linear-gradient(145deg, rgba(74,111,165,0.06) 0%, rgba(26,22,16,0.9) 100%)',
+              border: `1px solid ${hoverUaam ? 'rgba(74,111,165,0.4)' : 'rgba(74,111,165,0.15)'}`,
+              borderRadius: 20, padding: 0, cursor: 'pointer',
+              textAlign: 'left',
+              transition: 'all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+              transform: hoverUaam ? 'translateY(-4px)' : 'translateY(0)',
+              boxShadow: hoverUaam
+                ? '0 20px 60px rgba(74,111,165,0.15), 0 0 0 1px rgba(74,111,165,0.1) inset'
+                : '0 4px 24px rgba(0,0,0,0.3)',
+              overflow: 'hidden',
+              position: 'relative',
+            }}
+          >
+            {/* ブルーのアクセントライン */}
+            <div style={{
+              position: 'absolute', top: 0, left: 0, right: 0, height: 2,
+              background: 'linear-gradient(90deg, transparent 10%, #4A6FA5 50%, transparent 90%)',
+              opacity: hoverUaam ? 1 : 0.4,
+              transition: 'opacity 0.4s ease',
+            }} />
+            {renderBadge(uaamAttemptCount, {
+              background: 'rgba(74,111,165,0.22)',
+              border: 'rgba(74,111,165,0.45)',
+              color: '#8FB4E0',
+            })}
 
-          <div style={{ padding: '32px 28px' }}>
+            <div style={{ padding: getCardPadding(uaamAttemptCount) }}>
             {/* サブラベル */}
             <div style={{
               display: 'inline-flex', alignItems: 'center',
@@ -341,8 +458,10 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
                 letterSpacing: '0.08em',
               }}>才覚発動　領域展開</div>
             </div>
-          </div>
-        </button>
+            </div>
+          </button>
+          {renderHistoryArea('uaam', uaamAttemptCount, '#8FB4E0', hoverUaamHistory, setHoverUaamHistory)}
+        </div>
 
         {/* フッター */}
         <p style={{

--- a/src/screens/SelectScreen.jsx
+++ b/src/screens/SelectScreen.jsx
@@ -54,10 +54,10 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
     return count >= 2 ? '32px 28px 78px' : '32px 28px 58px';
   };
 
-  const renderBadge = (count, palette) => {
+  const renderBadge = (count, palette, testId) => {
     if (status === null || count <= 0) return null;
     return (
-      <div style={{
+      <div data-testid={testId} style={{
         position: 'absolute',
         top: 18,
         right: 18,
@@ -101,6 +101,7 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
           </span>
         )}
         <button
+          data-testid={`history-link-${kind}`}
           type="button"
           onClick={(e) => {
             e.stopPropagation();
@@ -219,6 +220,7 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
         {/* ─── 才覚領域カード ─── */}
         <div style={{ width: '100%', position: 'relative' }}>
           <button
+            data-testid="card-saikaku"
             onClick={handleSaikakuClick}
             onMouseEnter={() => setHoverSaikaku(true)}
             onMouseLeave={() => setHoverSaikaku(false)}
@@ -250,7 +252,7 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
               background: 'rgba(196,146,42,0.18)',
               border: 'rgba(196,146,42,0.45)',
               color: '#E8C47A',
-            })}
+            }, 'badge-saikaku')}
 
             <div style={{ padding: getCardPadding(saikakuAttemptCount) }}>
             {/* サブラベル */}
@@ -326,6 +328,7 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
         {/* ─── 才覚発動領域カード ─── */}
         <div style={{ width: '100%', position: 'relative' }}>
           <button
+            data-testid="card-uaam"
             onClick={handleUaamClick}
             onMouseEnter={() => setHoverUaam(true)}
             onMouseLeave={() => setHoverUaam(false)}
@@ -357,7 +360,7 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
               background: 'rgba(74,111,165,0.22)',
               border: 'rgba(74,111,165,0.45)',
               color: '#8FB4E0',
-            })}
+            }, 'badge-uaam')}
 
             <div style={{ padding: getCardPadding(uaamAttemptCount) }}>
             {/* サブラベル */}

--- a/src/screens/uaam/UAAMResultScreen.jsx
+++ b/src/screens/uaam/UAAMResultScreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useMemo, useState, useRef, useEffect } from 'react';
 import { signOutUser } from '../../firebase';
 import { UAAM_AXES, checkValidity, getVFlags } from '../../data/uaam_questions';
 import ActivationMatrix from './ActivationMatrix';
@@ -6,6 +6,7 @@ import AllPairsTriangle, { SymmetricMatrix } from './AllPairsTriangle';
 import ActivationPanel from '../../ActivationPanel';
 import SaikakuIntegration from './SaikakuIntegration';
 import { normalizeScores } from '../../utils/normalize';
+import { attemptToResultProps } from '../../utils/attemptAdapter';
 
 /* ============================================================
  * 定数
@@ -1494,17 +1495,29 @@ function RadarChart16({ scores }) {
 /* ============================================================
  * メインコンポーネント
  * ============================================================ */
-export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdmin, onLogout, onScoresRestored }) {
-  const { vAnswers, answers } = result;
+export default function UAAMResultScreen({ user, result, attemptData, isAdmin, onReset, onAdmin, onLogout, onScoresRestored }) {
+  const attemptProps = useMemo(
+    () => (attemptData ? attemptToResultProps(attemptData, 'uaam') : null),
+    [attemptData],
+  );
+  const effectiveResult = attemptProps?.result ?? result;
+  const isHistoryView = !!attemptData;
+  const { vAnswers, answers } = effectiveResult ?? {};
   // scores はローカル state で管理（復元時に即時反映）
   // normalizeScores が domainSubs/domainTotal を補完する唯一の場所
-  const [scores, setScores] = useState(() => normalizeScores(result.scores) ?? result.scores);
+  const [scores, setScores] = useState(() => normalizeScores(effectiveResult?.scores) ?? effectiveResult?.scores);
   // 統合分析は state で管理（バックフィル後に更新できるように）
-  const [analysis, setAnalysis] = useState(result.analysis || null);
+  const [analysis, setAnalysis] = useState(effectiveResult?.analysis || null);
   const [integrating, setIntegrating] = useState(false);
   const [integrateError, setIntegrateError] = useState('');
 
+  useEffect(() => {
+    setScores(normalizeScores(effectiveResult?.scores) ?? effectiveResult?.scores);
+    setAnalysis(effectiveResult?.analysis || null);
+  }, [effectiveResult]);
+
   const runIntegration = async () => {
+    if (isHistoryView) return;
     setIntegrating(true);
     setIntegrateError('');
     try {
@@ -1535,6 +1548,36 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
   // 妥当性チェック（V問フラグ判定）
   const validityResult = (vAnswers && answers) ? checkValidity(vAnswers, answers) : null;
 
+  if (!scores) {
+    return (
+      <div style={{
+        minHeight: '100vh',
+        background: LIGHT_BG,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+      }}>
+        <div style={{ textAlign: 'center' }}>
+          <p style={{ color: TEXT_PRIMARY, fontSize: 15, fontWeight: 700, margin: '0 0 16px' }}>
+            結果データを表示できませんでした
+          </p>
+          <button onClick={onReset} style={{
+            border: `1px solid ${BORDER}`,
+            background: WHITE,
+            color: TEXT_PRIMARY,
+            borderRadius: 10,
+            padding: '10px 18px',
+            cursor: 'pointer',
+            fontWeight: 700,
+          }}>
+            戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   const topType = determineType(scores, analysis);
   const subRadars = UAAM_AXES.map(axis => {
     const subs = scores[axis.key]?.subs || {};
@@ -1563,7 +1606,7 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
           }}>- 才覚発動マトリックス -</div>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          {isAdmin && (
+          {isAdmin && !isHistoryView && (
             <>
               <button onClick={onAdmin} style={{
                 padding: '6px 12px', borderRadius: 6, border: `1px solid ${BORDER}`,
@@ -1610,6 +1653,26 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
       </div>
 
       <div className="pdf-content-wrapper" style={{ maxWidth: 600, margin: '0 auto', padding: '24px 16px' }}>
+        {isHistoryView && (
+          <button
+            onClick={onReset}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              color: '#4A6FA5',
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '0.06em',
+              cursor: 'pointer',
+              textDecoration: 'underline',
+              textUnderlineOffset: 4,
+              marginBottom: 14,
+              padding: 0,
+            }}
+          >
+            最新の結果に戻る
+          </button>
+        )}
 
         {/* ===== 名前 + Activation Type + 今、発動している力（最上部） ===== */}
         <ActivationPanel scores={
@@ -1647,7 +1710,7 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
                 boxShadow: '0 2px 12px rgba(0,0,0,0.10)', border: `1px solid #E8E0D4` }}>
                 <SaikakuIntegration integration={analysis.saikaku_integration} />
               </div>
-            ) : (
+            ) : !isHistoryView ? (
               <Section>
                 <SectionHeader title="才覚発動統合分析" subtitle="才覚領域 × UAAM Integration" />
                 <p style={{ fontSize: 14, color: TEXT_SECONDARY, marginBottom: 16, lineHeight: 1.9 }}>
@@ -1676,7 +1739,7 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
                   </p>
                 )}
               </Section>
-            )}
+            ) : null}
 
           </>
         )}

--- a/src/utils/attemptAdapter.js
+++ b/src/utils/attemptAdapter.js
@@ -1,0 +1,74 @@
+export function attemptToResultProps(attempt, kind) {
+  if (!attempt) return null;
+
+  if (kind === 'saikaku') {
+    const result = attempt.full?.result ?? null;
+    if (!result) return null;
+
+    return {
+      result: {
+        ...result,
+        selectedKakuchiiki: attempt.full?.selectedKakuchiiki ?? result.kakuchiiki,
+      },
+    };
+  }
+
+  return {
+    result: {
+      scores: attempt.full?.scores ?? null,
+      analysis: attempt.full?.analysis ?? null,
+      answers: attempt.raw?.input?.answers ?? {},
+      vAnswers: attempt.raw?.input?.vAnswers ?? {},
+    },
+  };
+}
+
+export function legacyDocToAttempt(parentData, kind) {
+  if (!parentData) return null;
+
+  if (kind === 'saikaku') {
+    if (!parentData.result) return null;
+
+    return {
+      id: 'legacy-fallback',
+      isLegacy: true,
+      status: 'committed',
+      createdAt: parentData.createdAt ?? null,
+      summary: {
+        kakuchiiki: parentData.result?.kakuchiiki ?? parentData.selectedKakuchiiki ?? null,
+        createdAt: parentData.createdAt ?? null,
+      },
+      full: {
+        result: parentData.result,
+        analysis: null,
+        scores: null,
+        selectedKakuchiiki: parentData.selectedKakuchiiki ?? null,
+      },
+      raw: { input: {} },
+    };
+  }
+
+  if (!parentData.scores && !parentData.analysis) return null;
+
+  return {
+    id: 'legacy-fallback',
+    isLegacy: true,
+    status: 'committed',
+    createdAt: parentData.createdAt ?? null,
+    summary: {
+      typeName: parentData.analysis?.type_name ?? null,
+      createdAt: parentData.createdAt ?? null,
+    },
+    full: {
+      result: null,
+      analysis: parentData.analysis ?? null,
+      scores: parentData.scores ?? null,
+    },
+    raw: {
+      input: {
+        answers: parentData.answers ?? {},
+        vAnswers: parentData.vAnswers ?? {},
+      },
+    },
+  };
+}

--- a/tests/api/_helpers.js
+++ b/tests/api/_helpers.js
@@ -4,7 +4,15 @@ import app from '../../api/_app.js';
 import { db } from '../../api/lib/firebaseAdmin.js';
 import { getMockCallCount, resetMockCallCount } from '../../api/lib/anthropicClient.js';
 
-process.env.TEST_BYPASS_AUTH = '1';
+if (
+  process.env.TEST_BYPASS_AUTH !== '1'
+  || process.env.NODE_ENV !== 'test'
+  || !process.env.FIRESTORE_EMULATOR_HOST
+) {
+  throw new Error(
+    '[tests/api] TEST_BYPASS_AUTH=1 + NODE_ENV=test + FIRESTORE_EMULATOR_HOST が必要です。npm run test:api 経由で実行してください。'
+  );
+}
 
 export const api = request(app);
 export { FieldValue, Timestamp, getMockCallCount, resetMockCallCount };
@@ -47,9 +55,13 @@ export function uaamRequest(uid, body = minimalUaamBody()) {
 
 export async function clearUserState(collection, uid) {
   const parentRef = db.collection(collection).doc(uid);
-  const attempts = await parentRef.collection('attempts').get();
+  const [attempts, locks] = await Promise.all([
+    parentRef.collection('attempts').get(),
+    parentRef.collection('_locks').get(),
+  ]);
   const batch = db.batch();
   attempts.docs.forEach((snap) => batch.delete(snap.ref));
+  locks.docs.forEach((snap) => batch.delete(snap.ref));
   batch.delete(parentRef);
   await batch.commit();
 }

--- a/tests/api/_helpers.js
+++ b/tests/api/_helpers.js
@@ -81,6 +81,11 @@ export function setMockFail(enabled) {
   else delete process.env.MOCK_ANTHROPIC_FAIL;
 }
 
+export function setMockDelay(ms) {
+  if (ms > 0) process.env.MOCK_ANTHROPIC_DELAY_MS = String(ms);
+  else delete process.env.MOCK_ANTHROPIC_DELAY_MS;
+}
+
 export function legacySaikakuParent() {
   return {
     uid: 'legacy-user',

--- a/tests/api/_helpers.js
+++ b/tests/api/_helpers.js
@@ -1,0 +1,113 @@
+import request from 'supertest';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
+import app from '../../api/_app.js';
+import { db } from '../../api/lib/firebaseAdmin.js';
+import { getMockCallCount, resetMockCallCount } from '../../api/lib/anthropicClient.js';
+
+process.env.TEST_BYPASS_AUTH = '1';
+
+export const api = request(app);
+export { FieldValue, Timestamp, getMockCallCount, resetMockCallCount };
+
+export function minimalAnalyzeBody(overrides = {}) {
+  return {
+    idToken: 'stub',
+    name: 'Test User',
+    talent_top5: '観察\n対話\n構造化\n伴走\n説明',
+    talent_other: '文章化\n設計',
+    value_top5: '誠実\n成長\n貢献\n自由\n探究',
+    value_other: '調和\n美意識',
+    passion_top5: '教育\n対話\n旅\n創作\n起業',
+    passion_other: '読書\n音楽',
+    q1: '本音で生きる人を増やせなかったこと',
+    q2: '小さな学びの場を開く',
+    q3: '人が自分の言葉で進み始めている',
+    ...overrides,
+  };
+}
+
+export function minimalUaamBody(overrides = {}) {
+  const answers = {};
+  for (let i = 1; i <= 64; i += 1) answers[String(i)] = 3;
+  return {
+    idToken: 'stub',
+    answers,
+    vAnswers: { V1: 3, V2: 3, V3: 3 },
+    ...overrides,
+  };
+}
+
+export function analyzeRequest(uid, body = minimalAnalyzeBody()) {
+  return api.post('/api/analyze').set('x-test-uid', uid).send(body);
+}
+
+export function uaamRequest(uid, body = minimalUaamBody()) {
+  return api.post('/api/uaam').set('x-test-uid', uid).send(body);
+}
+
+export async function clearUserState(collection, uid) {
+  const parentRef = db.collection(collection).doc(uid);
+  const attempts = await parentRef.collection('attempts').get();
+  const batch = db.batch();
+  attempts.docs.forEach((snap) => batch.delete(snap.ref));
+  batch.delete(parentRef);
+  await batch.commit();
+}
+
+export async function seedParent(collection, uid, data) {
+  await db.collection(collection).doc(uid).set(data, { merge: true });
+}
+
+export async function updateParent(collection, uid, data) {
+  await db.collection(collection).doc(uid).update(data);
+}
+
+export async function seedAttempt(collection, uid, attemptId, data) {
+  await db.collection(collection).doc(uid).collection('attempts').doc(attemptId).set(data, { merge: true });
+}
+
+export async function getParent(collection, uid) {
+  const snap = await db.collection(collection).doc(uid).get();
+  return snap.exists ? snap.data() : null;
+}
+
+export async function listAttempts(collection, uid) {
+  const snap = await db.collection(collection).doc(uid).collection('attempts').get();
+  return snap.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
+export function setMockFail(enabled) {
+  if (enabled) process.env.MOCK_ANTHROPIC_FAIL = '1';
+  else delete process.env.MOCK_ANTHROPIC_FAIL;
+}
+
+export function legacySaikakuParent() {
+  return {
+    uid: 'legacy-user',
+    name: 'Legacy User',
+    email: 'legacy@example.com',
+    inputTalent: '観察',
+    inputValue: '誠実',
+    inputPassion: '探究',
+    selectedKakuchiiki: '問いに火を灯す人',
+    result: {
+      name: 'Legacy User',
+      talent: { axis1: { name: '言語化', items: ['観察'], percentage: 100 } },
+      value: { axis1: { name: '誠実', items: ['誠実'], percentage: 100 } },
+      passion: { axis1: { name: '探究', items: ['探究'], percentage: 100 } },
+      kakuchiiki: '問いに火を灯す人',
+      kakuchiiki_options: ['問いに火を灯す人'],
+      insight: 'legacy',
+      what: { products: [], actions: '', offer: '' },
+      reward: { economic: '', social: '', intrinsic: '', model: '' },
+    },
+    createdAt: Timestamp.now(),
+  };
+}
+
+export function stableHash(data) {
+  return JSON.stringify(data, (_key, value) => {
+    if (value && typeof value.toDate === 'function') return value.toDate().toISOString();
+    return value;
+  });
+}

--- a/tests/api/analyze-basic.test.js
+++ b/tests/api/analyze-basic.test.js
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  analyzeRequest,
+  clearUserState,
+  getMockCallCount,
+  getParent,
+  listAttempts,
+  resetMockCallCount,
+} from './_helpers.js';
+
+describe('API /api/analyze basic reservation flow', () => {
+  const uid = 'u-api-analyze-basic';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    resetMockCallCount();
+  });
+
+  it('commits the first two attempts and rejects the third before LLM call', async () => {
+    const first = await analyzeRequest(uid);
+    expect(first.status).toBe(200);
+    expect(first.body.kakuchiiki).toBeTruthy();
+    expect((await getParent('results', uid)).attemptCount).toBe(1);
+    expect(await listAttempts('results', uid)).toHaveLength(1);
+    expect(getMockCallCount('saikaku')).toBe(1);
+
+    const second = await analyzeRequest(uid);
+    expect(second.status).toBe(200);
+    expect((await getParent('results', uid)).attemptCount).toBe(2);
+    expect(await listAttempts('results', uid)).toHaveLength(2);
+    expect(getMockCallCount('saikaku')).toBe(2);
+
+    const third = await analyzeRequest(uid);
+    expect(third.status).toBe(429);
+    expect(third.body.code).toBe('LIMIT_EXCEEDED');
+    expect(getMockCallCount('saikaku')).toBe(2);
+  });
+});

--- a/tests/api/concurrent-from-one.test.js
+++ b/tests/api/concurrent-from-one.test.js
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  Timestamp,
+  analyzeRequest,
+  clearUserState,
+  getMockCallCount,
+  getParent,
+  resetMockCallCount,
+  seedAttempt,
+  seedParent,
+} from './_helpers.js';
+
+describe('API /api/analyze concurrency from attemptCount=1', () => {
+  const uid = 'u-conc-1';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    await seedParent('results', uid, { attemptCount: 1, pendingAttemptId: null, createdAt: Timestamp.now() });
+    await seedAttempt('results', uid, 'seed-1', { status: 'committed', createdAt: Timestamp.now() });
+    resetMockCallCount();
+  });
+
+  it('allows one request and rejects the concurrent pending conflict', async () => {
+    const responses = await Promise.all([analyzeRequest(uid), analyzeRequest(uid)]);
+    const statuses = responses.map((res) => res.status).sort();
+
+    expect(statuses).toEqual([200, 409]);
+    expect((await getParent('results', uid)).attemptCount).toBe(2);
+    expect(getMockCallCount('saikaku')).toBe(1);
+  });
+});

--- a/tests/api/concurrent-from-one.test.js
+++ b/tests/api/concurrent-from-one.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   Timestamp,
   analyzeRequest,
@@ -8,17 +8,21 @@ import {
   resetMockCallCount,
   seedAttempt,
   seedParent,
+  setMockDelay,
 } from './_helpers.js';
 
 describe('API /api/analyze concurrency from attemptCount=1', () => {
   const uid = 'u-conc-1';
 
   beforeEach(async () => {
+    setMockDelay(1500);
     await clearUserState('results', uid);
     await seedParent('results', uid, { attemptCount: 1, pendingAttemptId: null, createdAt: Timestamp.now() });
     await seedAttempt('results', uid, 'seed-1', { status: 'committed', createdAt: Timestamp.now() });
     resetMockCallCount();
   });
+
+  afterAll(() => setMockDelay(0));
 
   it('allows one request and rejects the concurrent pending conflict', async () => {
     const responses = await Promise.all([analyzeRequest(uid), analyzeRequest(uid)]);

--- a/tests/api/concurrent-from-two.test.js
+++ b/tests/api/concurrent-from-two.test.js
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  Timestamp,
+  analyzeRequest,
+  clearUserState,
+  getMockCallCount,
+  resetMockCallCount,
+  seedAttempt,
+  seedParent,
+} from './_helpers.js';
+
+describe('API /api/analyze concurrency from attemptCount=2', () => {
+  const uid = 'u-conc-2';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    await seedParent('results', uid, { attemptCount: 2, pendingAttemptId: null, createdAt: Timestamp.now() });
+    await seedAttempt('results', uid, 'seed-1', { status: 'committed', createdAt: Timestamp.now() });
+    await seedAttempt('results', uid, 'seed-2', { status: 'committed', createdAt: Timestamp.now() });
+    resetMockCallCount();
+  });
+
+  it('rejects both requests before the LLM call', async () => {
+    const responses = await Promise.all([analyzeRequest(uid), analyzeRequest(uid)]);
+
+    expect(responses.map((res) => res.status).sort()).toEqual([429, 429]);
+    expect(responses.every((res) => res.body.code === 'LIMIT_EXCEEDED')).toBe(true);
+    expect(getMockCallCount('saikaku')).toBe(0);
+  });
+});

--- a/tests/api/concurrent-from-zero.test.js
+++ b/tests/api/concurrent-from-zero.test.js
@@ -1,19 +1,23 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   analyzeRequest,
   clearUserState,
   getMockCallCount,
   getParent,
   resetMockCallCount,
+  setMockDelay,
 } from './_helpers.js';
 
 describe('API /api/analyze concurrency from attemptCount=0', () => {
   const uid = 'u-conc-0';
 
   beforeEach(async () => {
+    setMockDelay(1500);
     await clearUserState('results', uid);
     resetMockCallCount();
   });
+
+  afterAll(() => setMockDelay(0));
 
   it('allows one request and rejects the concurrent pending conflict', async () => {
     const responses = await Promise.all([analyzeRequest(uid), analyzeRequest(uid)]);

--- a/tests/api/concurrent-from-zero.test.js
+++ b/tests/api/concurrent-from-zero.test.js
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  analyzeRequest,
+  clearUserState,
+  getMockCallCount,
+  getParent,
+  resetMockCallCount,
+} from './_helpers.js';
+
+describe('API /api/analyze concurrency from attemptCount=0', () => {
+  const uid = 'u-conc-0';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    resetMockCallCount();
+  });
+
+  it('allows one request and rejects the concurrent pending conflict', async () => {
+    const responses = await Promise.all([analyzeRequest(uid), analyzeRequest(uid)]);
+    const statuses = responses.map((res) => res.status).sort();
+
+    expect(statuses).toEqual([200, 409]);
+    expect(responses.find((res) => res.status === 409).body.code).toBe('PENDING_CONFLICT');
+    expect((await getParent('results', uid)).attemptCount).toBe(1);
+    expect(getMockCallCount('saikaku')).toBe(1);
+  });
+});

--- a/tests/api/migration-idempotent.test.js
+++ b/tests/api/migration-idempotent.test.js
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  FieldValue,
+  analyzeRequest,
+  clearUserState,
+  legacySaikakuParent,
+  listAttempts,
+  resetMockCallCount,
+  seedParent,
+  stableHash,
+  updateParent,
+} from './_helpers.js';
+
+describe('API /api/analyze legacy migration idempotency', () => {
+  const uid = 'u-migrate-idempotent';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    await seedParent('results', uid, legacySaikakuParent());
+    resetMockCallCount();
+  });
+
+  it('does not rewrite or duplicate legacy-v1 when the parent looks legacy again', async () => {
+    const first = await analyzeRequest(uid);
+    expect(first.status).toBe(200);
+
+    const before = (await listAttempts('results', uid)).find((attempt) => attempt.id === 'legacy-v1');
+    const beforeHash = stableHash(before);
+
+    await updateParent('results', uid, { attemptCount: FieldValue.delete() });
+
+    const second = await analyzeRequest(uid);
+    expect(second.status).toBe(200);
+
+    const attempts = await listAttempts('results', uid);
+    const legacyDocs = attempts.filter((attempt) => attempt.id === 'legacy-v1');
+    expect(legacyDocs).toHaveLength(1);
+    expect(stableHash(legacyDocs[0])).toBe(beforeHash);
+  });
+});

--- a/tests/api/migration.test.js
+++ b/tests/api/migration.test.js
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  analyzeRequest,
+  clearUserState,
+  getParent,
+  legacySaikakuParent,
+  listAttempts,
+  resetMockCallCount,
+  seedParent,
+} from './_helpers.js';
+
+describe('API /api/analyze legacy migration', () => {
+  const uid = 'u-migrate1';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    await seedParent('results', uid, legacySaikakuParent());
+    resetMockCallCount();
+  });
+
+  it('creates legacy-v1 and commits the new attempt in one flow', async () => {
+    const response = await analyzeRequest(uid);
+
+    expect(response.status).toBe(200);
+    expect((await getParent('results', uid)).attemptCount).toBe(2);
+    const attempts = await listAttempts('results', uid);
+    expect(attempts).toHaveLength(2);
+
+    const legacy = attempts.find((attempt) => attempt.id === 'legacy-v1');
+    expect(legacy).toBeTruthy();
+    expect(legacy.isLegacy).toBe(true);
+    expect(legacy.status).toBe('committed');
+  });
+});

--- a/tests/api/pending-block.test.js
+++ b/tests/api/pending-block.test.js
@@ -1,0 +1,18 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { analyzeRequest, clearUserState, seedParent } from './_helpers.js';
+
+describe('API /api/analyze pending block', () => {
+  const uid = 'u-pending-block';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    await seedParent('results', uid, { attemptCount: 0, pendingAttemptId: 'dangling-id' });
+  });
+
+  it('returns 409 when a pending reservation exists', async () => {
+    const response = await analyzeRequest(uid);
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('PENDING_CONFLICT');
+  });
+});

--- a/tests/api/rollback.test.js
+++ b/tests/api/rollback.test.js
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  analyzeRequest,
+  clearUserState,
+  getParent,
+  listAttempts,
+  resetMockCallCount,
+  setMockFail,
+} from './_helpers.js';
+
+describe('API /api/analyze rollback', () => {
+  const uid = 'u-rollback';
+
+  beforeEach(async () => {
+    await clearUserState('results', uid);
+    resetMockCallCount();
+    setMockFail(true);
+  });
+
+  afterEach(() => {
+    setMockFail(false);
+  });
+
+  it('rolls the reservation back when the LLM fails', async () => {
+    const response = await analyzeRequest(uid);
+
+    expect(response.status).toBe(500);
+    expect((await getParent('results', uid)).attemptCount).toBe(0);
+    expect(await listAttempts('results', uid)).toHaveLength(0);
+  });
+});

--- a/tests/api/uaam-basic.test.js
+++ b/tests/api/uaam-basic.test.js
@@ -9,6 +9,7 @@ import {
   resetMockCallCount,
   seedAttempt,
   seedParent,
+  setMockDelay,
   uaamRequest,
 } from './_helpers.js';
 
@@ -35,12 +36,17 @@ describe('API /api/uaam basic reservation coverage', () => {
     const uid = 'u-uaam-concurrent';
     await clearUserState('uaam_results', uid);
     resetMockCallCount();
+    setMockDelay(1500);
 
-    const responses = await Promise.all([uaamRequest(uid), uaamRequest(uid)]);
+    try {
+      const responses = await Promise.all([uaamRequest(uid), uaamRequest(uid)]);
 
-    expect(responses.map((res) => res.status).sort()).toEqual([200, 409]);
-    expect((await getParent('uaam_results', uid)).attemptCount).toBe(1);
-    expect(getMockCallCount('uaam')).toBe(1);
+      expect(responses.map((res) => res.status).sort()).toEqual([200, 409]);
+      expect((await getParent('uaam_results', uid)).attemptCount).toBe(1);
+      expect(getMockCallCount('uaam')).toBe(1);
+    } finally {
+      setMockDelay(0);
+    }
   });
 
   it('migrates a legacy uaam parent before committing a new attempt', async () => {

--- a/tests/api/uaam-basic.test.js
+++ b/tests/api/uaam-basic.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  Timestamp,
+  clearUserState,
+  getMockCallCount,
+  getParent,
+  listAttempts,
+  minimalUaamBody,
+  resetMockCallCount,
+  seedAttempt,
+  seedParent,
+  uaamRequest,
+} from './_helpers.js';
+
+describe('API /api/uaam basic reservation coverage', () => {
+  beforeEach(() => {
+    resetMockCallCount();
+  });
+
+  it('enforces the two-attempt limit', async () => {
+    const uid = 'u-uaam-basic';
+    await clearUserState('uaam_results', uid);
+
+    expect((await uaamRequest(uid, minimalUaamBody())).status).toBe(200);
+    expect((await uaamRequest(uid, minimalUaamBody())).status).toBe(200);
+    const third = await uaamRequest(uid, minimalUaamBody());
+
+    expect(third.status).toBe(429);
+    expect(third.body.code).toBe('LIMIT_EXCEEDED');
+    expect((await getParent('uaam_results', uid)).attemptCount).toBe(2);
+    expect(getMockCallCount('uaam')).toBe(2);
+  });
+
+  it('handles concurrent requests with one commit and one conflict', async () => {
+    const uid = 'u-uaam-concurrent';
+    await clearUserState('uaam_results', uid);
+    resetMockCallCount();
+
+    const responses = await Promise.all([uaamRequest(uid), uaamRequest(uid)]);
+
+    expect(responses.map((res) => res.status).sort()).toEqual([200, 409]);
+    expect((await getParent('uaam_results', uid)).attemptCount).toBe(1);
+    expect(getMockCallCount('uaam')).toBe(1);
+  });
+
+  it('migrates a legacy uaam parent before committing a new attempt', async () => {
+    const uid = 'u-uaam-migrate';
+    await clearUserState('uaam_results', uid);
+    await seedParent('uaam_results', uid, {
+      scores: { mindset: { total: 60, max: 80, percentage: 75, subs: {} } },
+      analysis: { type_name: 'Legacy UAAM', narrative: 'legacy narrative' },
+      createdAt: Timestamp.now(),
+    });
+    resetMockCallCount();
+
+    const response = await uaamRequest(uid);
+
+    expect(response.status).toBe(200);
+    expect((await getParent('uaam_results', uid)).attemptCount).toBe(2);
+    const attempts = await listAttempts('uaam_results', uid);
+    expect(attempts.some((attempt) => attempt.id === 'legacy-v1' && attempt.isLegacy)).toBe(true);
+  });
+
+  it('rejects over-limit uaam requests before mock LLM calls', async () => {
+    const uid = 'u-uaam-limit';
+    await clearUserState('uaam_results', uid);
+    await seedParent('uaam_results', uid, { attemptCount: 2, pendingAttemptId: null });
+    await seedAttempt('uaam_results', uid, 'seed-1', { status: 'committed', createdAt: Timestamp.now() });
+    await seedAttempt('uaam_results', uid, 'seed-2', { status: 'committed', createdAt: Timestamp.now() });
+    resetMockCallCount();
+
+    const responses = await Promise.all([uaamRequest(uid), uaamRequest(uid)]);
+
+    expect(responses.map((res) => res.status).sort()).toEqual([429, 429]);
+    expect(getMockCallCount('uaam')).toBe(0);
+  });
+});

--- a/tests/e2e/_helpers.js
+++ b/tests/e2e/_helpers.js
@@ -1,0 +1,157 @@
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { expect } from '@playwright/test';
+
+const AUTH_BASE = 'http://localhost:9099/identitytoolkit.googleapis.com/v1';
+const API_KEY = 'fake-api-key';
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+  }
+  return getFirestore();
+}
+
+function collectionFor(kind) {
+  return kind === 'uaam' ? 'uaam_results' : 'results';
+}
+
+export async function createAuthUser(email, password) {
+  const signUp = await fetch(`${AUTH_BASE}/accounts:signUp?key=${API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, returnSecureToken: true }),
+  });
+  const data = await signUp.json();
+  if (!signUp.ok) throw new Error(`auth signUp failed: ${JSON.stringify(data)}`);
+
+  const update = await fetch(`${AUTH_BASE}/accounts:update?key=${API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      idToken: data.idToken,
+      emailVerified: true,
+      displayName: 'E2E User',
+      returnSecureToken: true,
+    }),
+  });
+  const updated = await update.json();
+  if (!update.ok) throw new Error(`auth update failed: ${JSON.stringify(updated)}`);
+
+  return {
+    uid: data.localId,
+    localId: data.localId,
+    idToken: updated.idToken || data.idToken,
+    email,
+    password,
+  };
+}
+
+export async function clearUser(uid) {
+  await Promise.all([
+    clearKind(uid, 'saikaku'),
+    clearKind(uid, 'uaam'),
+  ]);
+}
+
+export async function clearKind(uid, kind) {
+  const db = getDb();
+  const parentRef = db.collection(collectionFor(kind)).doc(uid);
+  const attempts = await parentRef.collection('attempts').get();
+  const batch = db.batch();
+  attempts.docs.forEach((snap) => batch.delete(snap.ref));
+  batch.delete(parentRef);
+  await batch.commit();
+}
+
+export async function seedUser(uid, kind, data) {
+  const db = getDb();
+  const parentRef = db.collection(collectionFor(kind)).doc(uid);
+  const parent = data.parent ?? data;
+  await parentRef.set(parent, { merge: true });
+
+  if (data.attempts) {
+    const writes = Object.entries(data.attempts).map(([id, attempt]) => {
+      return parentRef.collection('attempts').doc(id).set(attempt, { merge: true });
+    });
+    await Promise.all(writes);
+  }
+}
+
+export async function loginAs(page, email, password) {
+  await page.goto('/');
+  await page.getByRole('checkbox').check({ force: true });
+  await page.getByText('メールで入る').click();
+  await page.getByPlaceholder('メールアドレス').fill(email);
+  await page.getByPlaceholder('パスワード（6文字以上）').fill(password);
+  await page.locator('.login-btn-gold').click();
+  await expect(page.getByText('才覚解読プログラム')).toBeVisible({ timeout: 15000 });
+}
+
+export async function fillSaikakuForm(page) {
+  await page.getByPlaceholder('山田 太郎').fill('E2E User');
+  await page.getByPlaceholder('例：人の話を聞く、分かりやすく説明する、人の心を動かす...').fill('観察\n対話\n構造化\n伴走\n説明');
+  await page.getByPlaceholder('例：家族、誠実さ、自由、成長、貢献').fill('誠実\n成長\n貢献\n自由\n探究');
+  await page.getByPlaceholder('例：教育、コーチング、旅、音楽、起業...').fill('教育\n対話\n旅\n創作\n起業');
+  await page.getByPlaceholder('思いのままに書いてください').fill('本音で生きる人を増やせなかったこと');
+  await page.getByPlaceholder('具体的なシーン・行動・場所・誰といるか...').fill('小さな学びの場を開く');
+  await page.getByPlaceholder('人・組織・社会・世界...どんな変化が起きているか').fill('人が自分の言葉で進み始めている');
+  await page.getByRole('button', { name: /才覚領域を解析する/ }).click();
+}
+
+export function saikakuParent(attemptCount = 1) {
+  return {
+    attemptCount,
+    pendingAttemptId: null,
+    latestAttemptId: 'attempt-1',
+    selectedKakuchiiki: '問いに火を灯す人',
+    result: saikakuResult(),
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+  };
+}
+
+export function saikakuAttempt() {
+  return {
+    status: 'committed',
+    createdAt: Timestamp.now(),
+    summary: {
+      kakuchiiki: '問いに火を灯す人',
+      typeName: null,
+      createdAt: Timestamp.now(),
+    },
+    full: {
+      result: saikakuResult(),
+      analysis: null,
+      scores: null,
+      selectedKakuchiiki: '問いに火を灯す人',
+    },
+    raw: { input: {} },
+  };
+}
+
+function saikakuResult() {
+  return {
+    name: 'E2E User',
+    talent: {
+      axis1: { name: '言語化', english: 'Articulation', description: '言葉にする力', items: ['観察'], percentage: 40 },
+      axis2: { name: '設計力', english: 'Design', description: '組み立てる力', items: ['構造化'], percentage: 35 },
+      axis3: { name: '共感力', english: 'Empathy', description: '願いを読む力', items: ['伴走'], percentage: 25 },
+    },
+    value: {
+      axis1: { name: '誠実', english: 'Integrity', description: '本音と行動をそろえる', items: ['誠実'], percentage: 45 },
+      axis2: { name: '成長', english: 'Growth', description: '変化を歓迎する', items: ['成長'], percentage: 35 },
+      axis3: { name: '貢献', english: 'Contribution', description: '一歩を支える', items: ['貢献'], percentage: 20 },
+    },
+    passion: {
+      axis1: { name: '探究', english: 'Inquiry', description: '問いを深める', items: ['探究'], percentage: 42 },
+      axis2: { name: '発信', english: 'Expression', description: '外へ届ける', items: ['発信'], percentage: 33 },
+      axis3: { name: '実践', english: 'Practice', description: '試しながら形にする', items: ['実践'], percentage: 25 },
+    },
+    kakuchiiki: '問いに火を灯す人',
+    kakuchiiki_options: ['問いに火を灯す人', '本音を形にする案内人', '探究を道に変える人'],
+    insight: 'まだ言葉にならない願いを見つけ、次の一歩へ変えていく力があります。',
+    what: { products: ['対話メモを作る'], actions: '問いを書く', offer: '本音から動き出す人を増やす' },
+    reward: { economic: '講座化', social: '決断に立ち会う', intrinsic: '問いを見つける', model: '問いで支える' },
+  };
+}

--- a/tests/e2e/_helpers.js
+++ b/tests/e2e/_helpers.js
@@ -1,4 +1,5 @@
 import { initializeApp, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
 import { getFirestore, Timestamp } from 'firebase-admin/firestore';
 import { expect } from '@playwright/test';
 
@@ -10,6 +11,13 @@ function getDb() {
     initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
   }
   return getFirestore();
+}
+
+function getAdminAuth() {
+  if (!getApps().length) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+  }
+  return getAuth();
 }
 
 function collectionFor(kind) {
@@ -25,23 +33,15 @@ export async function createAuthUser(email, password) {
   const data = await signUp.json();
   if (!signUp.ok) throw new Error(`auth signUp failed: ${JSON.stringify(data)}`);
 
-  const update = await fetch(`${AUTH_BASE}/accounts:update?key=${API_KEY}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      idToken: data.idToken,
-      emailVerified: true,
-      displayName: 'E2E User',
-      returnSecureToken: true,
-    }),
+  await getAdminAuth().updateUser(data.localId, {
+    emailVerified: true,
+    displayName: 'E2E User',
   });
-  const updated = await update.json();
-  if (!update.ok) throw new Error(`auth update failed: ${JSON.stringify(updated)}`);
 
   return {
     uid: data.localId,
     localId: data.localId,
-    idToken: updated.idToken || data.idToken,
+    idToken: data.idToken,
     email,
     password,
   };

--- a/tests/e2e/badge-flow.spec.js
+++ b/tests/e2e/badge-flow.spec.js
@@ -11,10 +11,10 @@ test('badge display after a saikaku diagnosis', async ({ page }) => {
   await expect(page.getByTestId('badge-saikaku')).toHaveCount(0);
 
   await page.getByTestId('card-saikaku').click();
-  await expect(page.getByText('才覚領域を発見する')).toBeVisible();
+  await expect(page.getByRole('heading', { name: '才覚領域を発見する' })).toBeVisible({ timeout: 15000 });
   await fillSaikakuForm(page);
 
-  await expect(page.getByText('問いに火を灯す人')).toBeVisible({ timeout: 30000 });
+  await expect(page.getByText('問いに火を灯す人').first()).toBeVisible({ timeout: 30000 });
   await page.getByRole('button', { name: 'もう一度解析する' }).click();
 
   await expect(page.getByTestId('badge-saikaku')).toContainText('診断済み (1/2)', { timeout: 15000 });

--- a/tests/e2e/badge-flow.spec.js
+++ b/tests/e2e/badge-flow.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { clearUser, createAuthUser, fillSaikakuForm, loginAs } from './_helpers.js';
+
+test('badge display after a saikaku diagnosis', async ({ page }) => {
+  const email = `e2e-badge-${Date.now()}@example.com`;
+  const password = 'password123';
+  const user = await createAuthUser(email, password);
+  await clearUser(user.uid);
+
+  await loginAs(page, email, password);
+  await expect(page.getByTestId('badge-saikaku')).toHaveCount(0);
+
+  await page.getByTestId('card-saikaku').click();
+  await expect(page.getByText('才覚領域を発見する')).toBeVisible();
+  await fillSaikakuForm(page);
+
+  await expect(page.getByText('問いに火を灯す人')).toBeVisible({ timeout: 30000 });
+  await page.getByRole('button', { name: 'もう一度解析する' }).click();
+
+  await expect(page.getByTestId('badge-saikaku')).toContainText('診断済み (1/2)', { timeout: 15000 });
+  await expect(page.getByTestId('history-link-saikaku')).toContainText('履歴を見る (1)');
+});

--- a/tests/e2e/history-flow.spec.js
+++ b/tests/e2e/history-flow.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { clearUser, createAuthUser, loginAs, saikakuAttempt, saikakuParent, seedUser } from './_helpers.js';
+
+test('history list to detail and back', async ({ page }) => {
+  const email = `e2e-history-${Date.now()}@example.com`;
+  const password = 'password123';
+  const user = await createAuthUser(email, password);
+  await clearUser(user.uid);
+  await seedUser(user.uid, 'saikaku', {
+    parent: saikakuParent(1),
+    attempts: { 'attempt-1': saikakuAttempt() },
+  });
+
+  await loginAs(page, email, password);
+  await expect(page.getByTestId('history-link-saikaku')).toContainText('履歴を見る (1)', { timeout: 15000 });
+  await page.getByTestId('history-link-saikaku').click();
+
+  await expect(page.getByTestId('history-item')).toHaveCount(1);
+  await page.getByTestId('history-item').first().click();
+
+  await expect(page.getByText('問いに火を灯す人')).toBeVisible();
+  await page.getByRole('button', { name: '最新の結果に戻る' }).first().click();
+  await expect(page.getByText('才覚解読プログラム')).toBeVisible();
+});

--- a/tests/e2e/history-flow.spec.js
+++ b/tests/e2e/history-flow.spec.js
@@ -18,7 +18,7 @@ test('history list to detail and back', async ({ page }) => {
   await expect(page.getByTestId('history-item')).toHaveCount(1);
   await page.getByTestId('history-item').first().click();
 
-  await expect(page.getByText('問いに火を灯す人')).toBeVisible();
+  await expect(page.getByText('問いに火を灯す人').first()).toBeVisible();
   await page.getByRole('button', { name: '最新の結果に戻る' }).first().click();
   await expect(page.getByText('才覚解読プログラム')).toBeVisible();
 });

--- a/tests/e2e/limit-flow.spec.js
+++ b/tests/e2e/limit-flow.spec.js
@@ -18,11 +18,16 @@ test('attemptCount=2 blocks starting another saikaku diagnosis', async ({ page }
   await expect(page.getByTestId('badge-saikaku')).toContainText('診断済み (2/2)', { timeout: 15000 });
   await expect(page.getByText('診断は最大2回まで実施済み')).toBeVisible();
 
-  const dialogPromise = page.waitForEvent('dialog');
+  // window.alert は Playwright が自動 dismiss するため、capture 用に override する
+  const alertMessages = [];
+  await page.exposeFunction('__captureAlert', (msg) => alertMessages.push(msg));
+  await page.evaluate(() => {
+    window.alert = (msg) => window.__captureAlert(String(msg));
+  });
+
   await page.getByTestId('card-saikaku').click();
-  const dialog = await dialogPromise;
-  expect(dialog.message()).toContain('診断は最大2回まで実施済みです');
-  await dialog.accept();
+  await expect.poll(() => alertMessages.length, { timeout: 5000 }).toBeGreaterThan(0);
+  expect(alertMessages[0]).toContain('診断は最大2回まで実施済みです');
 
   await expect(page.getByText('才覚領域を発見する')).toHaveCount(0);
 });

--- a/tests/e2e/limit-flow.spec.js
+++ b/tests/e2e/limit-flow.spec.js
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { clearUser, createAuthUser, loginAs, saikakuAttempt, saikakuParent, seedUser } from './_helpers.js';
+
+test('attemptCount=2 blocks starting another saikaku diagnosis', async ({ page }) => {
+  const email = `e2e-limit-${Date.now()}@example.com`;
+  const password = 'password123';
+  const user = await createAuthUser(email, password);
+  await clearUser(user.uid);
+  await seedUser(user.uid, 'saikaku', {
+    parent: saikakuParent(2),
+    attempts: {
+      'attempt-1': saikakuAttempt(),
+      'attempt-2': saikakuAttempt(),
+    },
+  });
+
+  await loginAs(page, email, password);
+  await expect(page.getByTestId('badge-saikaku')).toContainText('診断済み (2/2)', { timeout: 15000 });
+  await expect(page.getByText('診断は最大2回まで実施済み')).toBeVisible();
+
+  const dialogPromise = page.waitForEvent('dialog');
+  await page.getByTestId('card-saikaku').click();
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toContain('診断は最大2回まで実施済みです');
+  await dialog.accept();
+
+  await expect(page.getByText('才覚領域を発見する')).toHaveCount(0);
+});

--- a/tests/fixtures/anthropic/saikaku-1.json
+++ b/tests/fixtures/anthropic/saikaku-1.json
@@ -1,0 +1,100 @@
+{
+  "name": "テストユーザー",
+  "talent": {
+    "axis1": {
+      "name": "言語化",
+      "english": "Articulation",
+      "description": "感じたことを言葉にする力",
+      "items": ["観察", "対話"],
+      "percentage": 40,
+      "top5": ["観察", "対話"]
+    },
+    "axis2": {
+      "name": "設計力",
+      "english": "Design",
+      "description": "流れを組み立てる力",
+      "items": ["構造化"],
+      "percentage": 35,
+      "top5": ["構造化"]
+    },
+    "axis3": {
+      "name": "共感力",
+      "english": "Empathy",
+      "description": "相手の奥にある願いを読む力",
+      "items": ["伴走"],
+      "percentage": 25,
+      "top5": ["伴走"]
+    }
+  },
+  "value": {
+    "axis1": {
+      "name": "誠実",
+      "english": "Integrity",
+      "description": "本音と行動をそろえる価値観",
+      "items": ["誠実"],
+      "percentage": 45,
+      "top5": ["誠実"]
+    },
+    "axis2": {
+      "name": "成長",
+      "english": "Growth",
+      "description": "変化を歓迎する価値観",
+      "items": ["成長"],
+      "percentage": 35,
+      "top5": ["成長"]
+    },
+    "axis3": {
+      "name": "貢献",
+      "english": "Contribution",
+      "description": "誰かの一歩を支える価値観",
+      "items": ["貢献"],
+      "percentage": 20,
+      "top5": ["貢献"]
+    }
+  },
+  "passion": {
+    "axis1": {
+      "name": "探究",
+      "english": "Inquiry",
+      "description": "問いを深め続ける情熱",
+      "items": ["探究"],
+      "percentage": 42,
+      "top5": ["探究"]
+    },
+    "axis2": {
+      "name": "発信",
+      "english": "Expression",
+      "description": "気づきを外へ届ける情熱",
+      "items": ["発信"],
+      "percentage": 33,
+      "top5": ["発信"]
+    },
+    "axis3": {
+      "name": "実践",
+      "english": "Practice",
+      "description": "試しながら形にする情熱",
+      "items": ["実践"],
+      "percentage": 25,
+      "top5": ["実践"]
+    }
+  },
+  "core_words": {
+    "talent_core": "言語化",
+    "value_core": "誠実",
+    "passion_core": "探究"
+  },
+  "kakuchiiki": "問いに火を灯す人",
+  "kakuchiiki_options": ["問いに火を灯す人", "本音を形にする案内人", "探究を道に変える人"],
+  "insight": "まだ言葉にならない願いを見つけ、次の一歩へ変えていく力があります。",
+  "what": {
+    "products": ["対話メモを作る", "小さな勉強会を開く", "問いのワークを設計する", "伴走セッションを届ける", "探究コミュニティを育てる"],
+    "actions": "今日浮かんだ問いを一つ書き出す",
+    "offer": "本音から動き出す人を増やす"
+  },
+  "reward": {
+    "economic": "対話セッションや講座として収益化できる",
+    "social": "誰かの決断の場面に立ち会える",
+    "intrinsic": "問いを見つけるほど自然に動き出す",
+    "model": "問いを言葉にし、人の一歩を支えることで生きていける"
+  }
+}

--- a/tests/fixtures/anthropic/uaam-1.json
+++ b/tests/fixtures/anthropic/uaam-1.json
@@ -1,0 +1,25 @@
+{
+  "primary_type": "NAVIGATOR",
+  "secondary_type": "BUILDER",
+  "type_name": "実装する案内人",
+  "type_description": "構想を現実の道筋へ変える人",
+  "axis_analysis": {
+    "mindset": "意味を見つける力が行動の起点になります。",
+    "literacy": "学んだことを整理して伝える流れが強みです。",
+    "competency": "対話と構造化を組み合わせて前進できます。",
+    "impact": "小さく試し、改善しながら影響を広げます。"
+  },
+  "quadrant_analysis": {
+    "vision_quadrant": "願いを言葉にし、学びで支えるビジョン型です。",
+    "execution_quadrant": "実装の粒度まで落とし込み、周囲を動かせます。"
+  },
+  "strengths": ["構造化", "伴走", "実装"],
+  "growth_areas": ["優先順位", "委任", "継続設計"],
+  "narrative": "見えにくい可能性を整理し、最初の行動へ変える力があります。大きな構想ほど、小さな実験に分けることで前進が速くなります。",
+  "action_suggestions": ["一つだけ実験を決める", "成果を記録する", "次の協力者に共有する"],
+  "saikaku_integration": {
+    "activation_core": "問いを構造化し、実装へつなげると才覚が動きます。",
+    "mission_direction": "人が自分の道を選べる場をつくる方向です。",
+    "flow_route": "対話、整理、実験の順で進めると流れに乗れます。"
+  }
+}

--- a/tests/rules/_helpers.js
+++ b/tests/rules/_helpers.js
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { doc, setDoc } from 'firebase/firestore';
+
+export async function setupRulesTest() {
+  const testEnv = await initializeTestEnvironment({
+    projectId: 'demo-saikaku',
+    firestore: {
+      rules: readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8'),
+    },
+  });
+  await testEnv.clearFirestore();
+  return testEnv;
+}
+
+export async function cleanupRulesTest(testEnv) {
+  await testEnv?.cleanup();
+}
+
+export function authedDb(testEnv, uid) {
+  return testEnv.authenticatedContext(uid).firestore();
+}
+
+export async function seedDoc(testEnv, path, data) {
+  await testEnv.withSecurityRulesDisabled(async (context) => {
+    await setDoc(doc(context.firestore(), path), data);
+  });
+}

--- a/tests/rules/attempts-read.test.js
+++ b/tests/rules/attempts-read.test.js
@@ -1,0 +1,34 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+import { doc, getDoc, Timestamp } from 'firebase/firestore';
+import { authedDb, cleanupRulesTest, seedDoc, setupRulesTest } from './_helpers.js';
+
+describe('Firestore rules: attempts read', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await setupRulesTest();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedDoc(testEnv, 'results/u1/attempts/x', {
+      status: 'committed',
+      createdAt: Timestamp.now(),
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupRulesTest(testEnv);
+  });
+
+  it('allows the owner to read their attempt', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertSucceeds(getDoc(doc(db, 'results/u1/attempts/x')));
+  });
+
+  it('denies another user reading the attempt', async () => {
+    const db = authedDb(testEnv, 'u2');
+    await assertFails(getDoc(doc(db, 'results/u1/attempts/x')));
+  });
+});

--- a/tests/rules/attempts-read.test.js
+++ b/tests/rules/attempts-read.test.js
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
 import { assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
-import { doc, getDoc, Timestamp } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, Timestamp } from 'firebase/firestore';
 import { authedDb, cleanupRulesTest, seedDoc, setupRulesTest } from './_helpers.js';
 
 describe('Firestore rules: attempts read', () => {
@@ -16,19 +16,33 @@ describe('Firestore rules: attempts read', () => {
       status: 'committed',
       createdAt: Timestamp.now(),
     });
+    await seedDoc(testEnv, 'results/u1/attempts/y', {
+      status: 'committed',
+      createdAt: Timestamp.now(),
+    });
   });
 
   afterAll(async () => {
     await cleanupRulesTest(testEnv);
   });
 
-  it('allows the owner to read their attempt', async () => {
+  it('allows the owner to read their attempt (get)', async () => {
     const db = authedDb(testEnv, 'u1');
     await assertSucceeds(getDoc(doc(db, 'results/u1/attempts/x')));
   });
 
-  it('denies another user reading the attempt', async () => {
+  it('allows the owner to list their attempts', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertSucceeds(getDocs(collection(db, 'results/u1/attempts')));
+  });
+
+  it('denies another user reading the attempt (get)', async () => {
     const db = authedDb(testEnv, 'u2');
     await assertFails(getDoc(doc(db, 'results/u1/attempts/x')));
+  });
+
+  it('denies another user listing the attempts', async () => {
+    const db = authedDb(testEnv, 'u2');
+    await assertFails(getDocs(collection(db, 'results/u1/attempts')));
   });
 });

--- a/tests/rules/attempts-write-denied.test.js
+++ b/tests/rules/attempts-write-denied.test.js
@@ -1,0 +1,30 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails } from '@firebase/rules-unit-testing';
+import { doc, setDoc } from 'firebase/firestore';
+import { authedDb, cleanupRulesTest, setupRulesTest } from './_helpers.js';
+
+describe('Firestore rules: attempts write deny', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await setupRulesTest();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  afterAll(async () => {
+    await cleanupRulesTest(testEnv);
+  });
+
+  it('denies owner writes to results attempts', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(setDoc(doc(db, 'results/u1/attempts/x'), { foo: 1 }));
+  });
+
+  it('denies owner writes to uaam_results attempts', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(setDoc(doc(db, 'uaam_results/u1/attempts/x'), { foo: 1 }));
+  });
+});

--- a/tests/rules/create-flow.test.js
+++ b/tests/rules/create-flow.test.js
@@ -1,0 +1,35 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+import { doc, setDoc, Timestamp } from 'firebase/firestore';
+import { authedDb, cleanupRulesTest, setupRulesTest } from './_helpers.js';
+
+describe('Firestore rules: create flow', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await setupRulesTest();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  afterAll(async () => {
+    await cleanupRulesTest(testEnv);
+  });
+
+  it('allows creating a consent-only parent doc', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertSucceeds(setDoc(doc(db, 'results/u1'), { consentAt: Timestamp.now() }));
+  });
+
+  it('denies creating parent docs with extra fields', async () => {
+    const db = authedDb(testEnv, 'u2');
+    await assertFails(setDoc(doc(db, 'results/u2'), { consentAt: Timestamp.now(), foo: 'bar' }));
+  });
+
+  it('denies creating parent docs with non-timestamp consentAt', async () => {
+    const db = authedDb(testEnv, 'u3');
+    await assertFails(setDoc(doc(db, 'results/u3'), { consentAt: 'not-a-date' }));
+  });
+});

--- a/tests/rules/delete.test.js
+++ b/tests/rules/delete.test.js
@@ -1,0 +1,35 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails } from '@firebase/rules-unit-testing';
+import { deleteDoc, doc, Timestamp } from 'firebase/firestore';
+import { authedDb, cleanupRulesTest, seedDoc, setupRulesTest } from './_helpers.js';
+
+describe('Firestore rules: delete deny', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await setupRulesTest();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedDoc(testEnv, 'results/u1', { consentAt: Timestamp.now() });
+    await seedDoc(testEnv, 'results/u1/attempts/x', {
+      status: 'committed',
+      createdAt: Timestamp.now(),
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupRulesTest(testEnv);
+  });
+
+  it('denies deleting a parent result doc', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(deleteDoc(doc(db, 'results/u1')));
+  });
+
+  it('denies deleting an attempt doc', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(deleteDoc(doc(db, 'results/u1/attempts/x')));
+  });
+});

--- a/tests/rules/locks-denied.test.js
+++ b/tests/rules/locks-denied.test.js
@@ -1,0 +1,52 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails } from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc, Timestamp } from 'firebase/firestore';
+import { authedDb, cleanupRulesTest, seedDoc, setupRulesTest } from './_helpers.js';
+
+describe('Firestore rules: _locks subcollection (Admin SDK only)', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await setupRulesTest();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedDoc(testEnv, 'results/u1/_locks/reservation', {
+      attemptId: 'a1',
+      acquiredAt: Timestamp.now(),
+    });
+    await seedDoc(testEnv, 'uaam_results/u1/_locks/reservation', {
+      attemptId: 'a1',
+      acquiredAt: Timestamp.now(),
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupRulesTest(testEnv);
+  });
+
+  it('denies the owner reading their reservation lock', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(getDoc(doc(db, 'results/u1/_locks/reservation')));
+    await assertFails(getDoc(doc(db, 'uaam_results/u1/_locks/reservation')));
+  });
+
+  it('denies another user reading the lock', async () => {
+    const db = authedDb(testEnv, 'u2');
+    await assertFails(getDoc(doc(db, 'results/u1/_locks/reservation')));
+    await assertFails(getDoc(doc(db, 'uaam_results/u1/_locks/reservation')));
+  });
+
+  it('denies the owner writing a reservation lock', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(setDoc(doc(db, 'results/u1/_locks/reservation'), {
+      attemptId: 'evil',
+      acquiredAt: Timestamp.now(),
+    }));
+    await assertFails(setDoc(doc(db, 'uaam_results/u1/_locks/reservation'), {
+      attemptId: 'evil',
+      acquiredAt: Timestamp.now(),
+    }));
+  });
+});

--- a/tests/rules/parent-fields.test.js
+++ b/tests/rules/parent-fields.test.js
@@ -1,0 +1,54 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+import { doc, Timestamp, updateDoc } from 'firebase/firestore';
+import { authedDb, cleanupRulesTest, seedDoc, setupRulesTest } from './_helpers.js';
+
+describe('Firestore rules: parent fields', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await setupRulesTest();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedDoc(testEnv, 'results/u1', { consentAt: Timestamp.now() });
+  });
+
+  afterAll(async () => {
+    await cleanupRulesTest(testEnv);
+  });
+
+  it('allows selectedKakuchiiki string updates', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertSucceeds(updateDoc(doc(db, 'results/u1'), { selectedKakuchiiki: 'foo' }));
+  });
+
+  it('denies selectedKakuchiiki values over the size limit', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(updateDoc(doc(db, 'results/u1'), { selectedKakuchiiki: 'a'.repeat(300) }));
+  });
+
+  it('denies selectedKakuchiiki non-string values', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(updateDoc(doc(db, 'results/u1'), { selectedKakuchiiki: 12345 }));
+  });
+
+  it('denies consentAt non-timestamp values', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(updateDoc(doc(db, 'results/u1'), { consentAt: 'not-a-date' }));
+  });
+
+  it('denies protected result field updates', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertFails(updateDoc(doc(db, 'results/u1'), { result: { kakuchiiki: 'foo' } }));
+  });
+
+  it('allows consentAt and selectedKakuchiiki together when valid', async () => {
+    const db = authedDb(testEnv, 'u1');
+    await assertSucceeds(updateDoc(doc(db, 'results/u1'), {
+      consentAt: Timestamp.now(),
+      selectedKakuchiiki: 'foo',
+    }));
+  });
+});

--- a/tests/unit/adapter.test.js
+++ b/tests/unit/adapter.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { attemptToResultProps, legacyDocToAttempt } from '../../src/utils/attemptAdapter';
+
+describe('attemptAdapter', () => {
+  it('returns null when attempt is null', () => {
+    expect(attemptToResultProps(null, 'saikaku')).toBeNull();
+  });
+
+  it('maps a saikaku attempt to ResultScreen props', () => {
+    const attempt = {
+      full: {
+        result: {
+          kakuchiiki: '問いに火を灯す人',
+          kakuchiiki_options: ['問いに火を灯す人'],
+        },
+        selectedKakuchiiki: '本音を形にする案内人',
+      },
+    };
+
+    expect(attemptToResultProps(attempt, 'saikaku')).toEqual({
+      result: {
+        kakuchiiki: '問いに火を灯す人',
+        kakuchiiki_options: ['問いに火を灯す人'],
+        selectedKakuchiiki: '本音を形にする案内人',
+      },
+    });
+  });
+
+  it('maps a uaam attempt to UAAMResultScreen props', () => {
+    const attempt = {
+      full: {
+        scores: { mindset: { total: 60 } },
+        analysis: { type_name: '実装する案内人' },
+      },
+      raw: {
+        input: {
+          answers: { 1: 3 },
+          vAnswers: { V1: 4 },
+        },
+      },
+    };
+
+    expect(attemptToResultProps(attempt, 'uaam')).toEqual({
+      result: {
+        scores: { mindset: { total: 60 } },
+        analysis: { type_name: '実装する案内人' },
+        answers: { 1: 3 },
+        vAnswers: { V1: 4 },
+      },
+    });
+  });
+
+  it('creates a synthetic legacy saikaku attempt from a parent doc', () => {
+    const attempt = legacyDocToAttempt({
+      result: { kakuchiiki: '問いに火を灯す人' },
+      selectedKakuchiiki: '問いに火を灯す人',
+      createdAt: '2026-05-01',
+    }, 'saikaku');
+
+    expect(attempt).toMatchObject({
+      id: 'legacy-fallback',
+      isLegacy: true,
+      status: 'committed',
+      summary: { kakuchiiki: '問いに火を灯す人' },
+      full: {
+        result: { kakuchiiki: '問いに火を灯す人' },
+        selectedKakuchiiki: '問いに火を灯す人',
+      },
+    });
+  });
+
+  it('returns null for empty legacy saikaku parents', () => {
+    expect(legacyDocToAttempt({}, 'saikaku')).toBeNull();
+  });
+});

--- a/tests/unit/ui/select-badge.test.jsx
+++ b/tests/unit/ui/select-badge.test.jsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../../src/firebase', () => ({
+  signOutUser: vi.fn(),
+}));
+
+vi.mock('../../../src/hooks/useDiagnosisStatus', () => ({
+  default: vi.fn(),
+}));
+
+import useDiagnosisStatus from '../../../src/hooks/useDiagnosisStatus';
+import SelectScreen from '../../../src/screens/SelectScreen';
+
+const user = { uid: 'u1', displayName: 'Test User' };
+const noop = () => {};
+
+function renderSelect() {
+  return render(
+    <SelectScreen
+      user={user}
+      isAdmin={false}
+      onSelectSaikaku={noop}
+      onSelectUaam={noop}
+      onSelectHistory={noop}
+      onAdmin={noop}
+      onLogout={noop}
+    />,
+  );
+}
+
+describe('SelectScreen badge', () => {
+  it('hides badges while loading', () => {
+    useDiagnosisStatus.mockReturnValue(null);
+
+    renderSelect();
+
+    expect(screen.queryByTestId('badge-saikaku')).toBeNull();
+    expect(screen.queryByText(/診断済み/)).toBeNull();
+  });
+
+  it('shows 1/2 for saikaku when attemptCount=1', () => {
+    useDiagnosisStatus.mockReturnValue({
+      saikaku: { attemptCount: 1, hasResult: true },
+      uaam: { attemptCount: 0, hasResult: false },
+    });
+
+    renderSelect();
+
+    expect(screen.getByTestId('badge-saikaku')).toHaveTextContent('診断済み (1/2)');
+    expect(screen.getByTestId('history-link-saikaku')).toHaveTextContent('履歴を見る (1)');
+  });
+
+  it('shows 2/2 and the limit notice for saikaku', () => {
+    useDiagnosisStatus.mockReturnValue({
+      saikaku: { attemptCount: 2, hasResult: true },
+      uaam: { attemptCount: 0, hasResult: false },
+    });
+
+    renderSelect();
+
+    expect(screen.getByTestId('badge-saikaku')).toHaveTextContent('診断済み (2/2)');
+    expect(screen.getByText('診断は最大2回まで実施済み')).toBeInTheDocument();
+  });
+
+  it('shows the hook-normalized legacy fallback count', () => {
+    useDiagnosisStatus.mockReturnValue({
+      saikaku: { attemptCount: 1, hasResult: true },
+      uaam: { attemptCount: 0, hasResult: false },
+    });
+
+    renderSelect();
+
+    expect(screen.getByTestId('badge-saikaku')).toHaveTextContent('(1/2)');
+  });
+
+  it('shows uaam badge independently from saikaku', () => {
+    useDiagnosisStatus.mockReturnValue({
+      saikaku: { attemptCount: 0, hasResult: false },
+      uaam: { attemptCount: 1, hasResult: true },
+    });
+
+    renderSelect();
+
+    expect(screen.queryByTestId('badge-saikaku')).toBeNull();
+    expect(screen.getByTestId('badge-uaam')).toHaveTextContent('診断済み (1/2)');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'node',
+    environmentMatchGlobs: [
+      ['tests/unit/**/*.jsx', 'jsdom'],
+      ['tests/unit/**/*.tsx', 'jsdom'],
+      ['tests/unit/ui/**', 'jsdom'],
+    ],
+    setupFiles: ['tests/setup.js'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary

- **Reservation Transaction パターン** で並行 LLM 多重発火を防止しつつ最大 2 回上限を Firestore Tx で強制
- **診断済みバッジ + 履歴 UI** を SelectScreen / HistoryScreen に追加。MATRIX も常時バッジ表示 (パスは診断開始のみ)
- **4 層自動テスト** (unit 10 / rules 20 / api 12 / e2e 3) を `npm run test:all` で実行可能に

## 主要変更

### バックエンド (Phase 1)
- `api/lib/attempts.js`: `reserveAttempt` / `commitAttempt` / `rollbackAttempt` + `_locks/reservation` での pessimistic lock (TTL 10 分) + legacy `legacy-v1` deterministic migration
- `api/lib/anthropicClient.js`: MOCK_ANTHROPIC=1 / MOCK_ANTHROPIC_FAIL / MOCK_ANTHROPIC_DELAY_MS の3種類のテスト用モード
- `api/analyze.js` / `api/uaam.js`: Reservation フロー (reserve→LLM→commit、失敗時 rollback)。レスポンス形状不変
- `firestore.rules`: `consentAt` / `selectedKakuchiiki` への限定 update + 型/サイズ検証 + `attempts/*` `_locks/*` Admin SDK only

### フロントエンド (Phase 2-3)
- `src/hooks/useDiagnosisStatus.js`: results / uaam_results を onSnapshot で監視、legacy fallback 内蔵
- `src/utils/attemptAdapter.js`: attempt → ResultScreen/UAAMResultScreen props 変換 + Read-Time Fallback (`legacyDocToAttempt`)
- `src/screens/HistoryScreen.jsx`: kind別カラートークン、committed のみ表示、空時は親doc合成
- `src/screens/SelectScreen.jsx`: 才覚=ゴールド/MATRIX=ブルー pill「診断済み (n/2)」、履歴リンク、attemptCount===2 で alert ガード
- `src/screens/{ResultScreen,uaam/UAAMResultScreen}.jsx`: `attemptData` props で履歴 replay、保存処理を抑止

### テスト (Phase 4-6)
- `npm run test:all`: unit + rules + api + e2e を直列実行
- API/Rules テストは emulator 上で実体動作を検証 (`@firebase/rules-unit-testing`, `supertest`)
- E2E orchestrator が emulator/API/Vite を順次起動

### 設計判断 (Phase 7)
- `docs/design-rationale.md`: なぜサブコレクション/Reservation Tx/Read-Time Fallback/MATRIX (a) 受験者制限を採用したか
- `docs/testing.md`: 4 層テストの実行方法 + LLM mock + TEST_BYPASS_AUTH ガード仕様

## 検証

| 層 | 結果 |
|----|------|
| Unit | 10/10 ✅ |
| Rules | 20/20 ✅ |
| API | 12/12 ✅ |
| E2E | (CI未実行) |
| `npm run build` | ✅ |

API テストの主要シナリオ:
- 1/2/3 回目挙動 + 3 回目で mock LLM call count = 0
- attemptCount=0 同時 2 リクエスト → 一方 200 / 一方 409、LLM call=1 (コスト保護)
- attemptCount=1 同時 2 リクエスト → 一方 200 / 一方 409
- attemptCount=2 同時 2 リクエスト → 両方 429、LLM call=0
- pending 残存中の新規リクエスト → 409
- LLM 失敗時の rollback で attemptCount が元に戻る
- legacy 親doc → 1 回診断 → `legacy-v1` + 新id、attemptCount=2
- migration 連続呼び出しで `legacy-v1` 重複作成されない (deterministic ID 検証)

## Codex Review 反映済み (Critical/High)

- TEST_BYPASS_AUTH を 三重ガード (`NODE_ENV=test` + `FIRESTORE_EMULATOR_HOST`) で強化
- Reservation Lock TTL 10 分 (LLM タイムアウトでも自動回復)
- `_locks/*` の rules テスト追加
- `attempts/*` の collection list 権限テスト追加
- `clearUserState` で `_locks` も削除 (テスト汚染防止)

## 別 issue 化が望ましい既存課題 (今回スコープ外)

- `UAAM_PASS` のサーバー側検証 (フロント直書きで curl 回避可能。今回確定の (a) 受験者制限を厳守するなら必要)
- UAAM answers の必須 ID 検証 (1〜64 の欠落を 3 として採点する既存バグ)
- LLM レスポンスの構造的検証 (`axis2` 欠けで ResultScreen がランタイムクラッシュ)
- `api/uaam.js` で `saikakuSection` を組み立てるが `userMsg` に未結合 (UAAM 統合分析が機能していない既存バグ)
- `selectedKakuchiiki` の値が `kakuchiiki_options` 内かサーバー検証

## Test plan

- [ ] `npm run test:all` がローカルで全部 green
- [ ] 既存ユーザーで diagnosis 1 回試行 → SelectScreen で「診断済み (1/2)」が表示される
- [ ] 履歴を見るリンクから HistoryScreen → 詳細遷移 → 戻る
- [ ] 2 回診断後に 3 回目を試行 → モーダル抑止
- [ ] パスワード入力前に MATRIX のバッジ・履歴が表示される
- [ ] パスワード入力後に MATRIX 診断が開始できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)