### PR TITLE
fix(tests): LoginScreen テストのjsdom env と新規パスワード再入力欄を反映

### DIFF
--- a/tests/LoginScreen.test.jsx
+++ b/tests/LoginScreen.test.jsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -52,6 +53,9 @@ async function fillAndSubmit(user, container, { email, password, displayName, mo
   }
   await user.type(screen.getByPlaceholderText('メールアドレス'), email);
   await user.type(screen.getByPlaceholderText('パスワード（6文字以上）'), password);
+  if (mode === 'signup') {
+    await user.type(screen.getByPlaceholderText('パスワード（確認のため再入力）'), password);
+  }
 
   // login-btn-gold クラスの送信ボタンをクリック
   const submitBtn = container.querySelector('.login-btn-gold');


### PR DESCRIPTION
## Summary

直近コミット \`a16865a feat: 新規登録時にパスワード再入力欄を追加し誤入力を防止\` 以降、\`tests/LoginScreen.test.jsx\` が以下2点の理由で 6/6 全失敗していたのを修正。

1. **jsdom env が effective でない**: vitest 4 へのアップデート + テストスイート構成変更により、\`vite.config.js\` のグローバル \`environment: 'jsdom'\` がこの UI テスト1ファイルでだけ効かなくなっていた（\`document is not defined\`、\`Cannot read properties of undefined (reading 'navigator')\` 等）
2. **signup フォームの新規パスワード再入力欄が未入力**: \`fillAndSubmit\` ヘルパーが「パスワード（確認のため再入力）」フィールドをスキップしていたため、コンポーネントが「パスワードが一致しません」エラーで先に進まずモック Firebase 呼び出しに到達できなかった

## 変更内容

\`tests/LoginScreen.test.jsx\` のみの**テスト側修正**:
- 先頭に \`// @vitest-environment jsdom\` pragma を追加（vite.config.js のグローバル設定は他スイートが node 環境前提のため変更しない）
- \`fillAndSubmit\` ヘルパーに \`signup\` モード時の確認パスワード入力を追加

## テスト結果

\`\`\`
$ npx vitest run tests/LoginScreen.test.jsx
PASS (6) FAIL (0)
\`\`\`

## 修正委任メモ

修正は **Codex (GPT-5.5)** に委任してパッチを生成。所要時間 35 秒、変更行数 +4。検証 (\`npx vitest run\`) で 6/6 PASS を確認後にコミット・push。

## 関連

- 関連 PR: #26 (Issue #4 の作業中に AllPairsTriangle 側で同じ env 問題を pragma で個別対処済み)
- mainで連続して落ちていた regression のため早期マージ推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)