### PR TITLE
fix: revert indexed query to avoid composite index dependency

### DIFF
--- a/api/me/history.js
+++ b/api/me/history.js
@@ -40,29 +40,12 @@ export default withMeHandler(async function handler(req, res) {
   if (!config) return res.status(422).json({ error: 'kind must be saikaku or uaam' });
 
   const parentRef = db.collection(config.collection).doc(decoded.uid);
-  const attemptsRef = parentRef.collection('attempts');
-  const parentSnapPromise = parentRef.get();
-  const committedSnapPromise = attemptsRef
-    .where('status', '==', 'committed')
-    .orderBy('createdAt', 'desc')
-    .limit(20)
-    .get();
-  const pendingSnapPromise = parentSnapPromise.then((parentSnap) => {
-    const pendingAttemptId = parentSnap.exists ? parentSnap.data()?.pendingAttemptId : null;
-    return pendingAttemptId ? attemptsRef.doc(pendingAttemptId).get() : null;
-  });
-
-  const [parentSnap, committedSnap, pendingSnap] = await Promise.all([
-    parentSnapPromise,
-    committedSnapPromise,
-    pendingSnapPromise,
+  const [parentSnap, attemptsSnap] = await Promise.all([
+    parentRef.get(),
+    parentRef.collection('attempts').get(),
   ]);
   const parentData = parentSnap.exists ? parentSnap.data() : null;
-  const committedDocs = committedSnap.docs.map((docSnap) => attemptFromDoc(docSnap, kind));
-  const pendingAttemptDoc = pendingSnap?.exists ? attemptFromDoc(pendingSnap, kind) : null;
-  const attemptDocs = pendingAttemptDoc?.status === 'pending'
-    ? [...committedDocs, pendingAttemptDoc]
-    : committedDocs;
+  const attemptDocs = attemptsSnap.docs.map((docSnap) => attemptFromDoc(docSnap, kind));
   const { committedAttempts, pendingAttempt } = listFromAttempts(attemptDocs, parentData, kind);
   const attempts = committedAttempts.map((attempt) => attemptListItem(attempt, kind));
   const pendingListItem = pendingAttempt ? attemptListItem(pendingAttempt, kind) : null;

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -6,14 +6,6 @@
       "fields": [
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "attempts",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
     }
   ],
   "fieldOverrides": []

--- a/tests/api/me-history.test.js
+++ b/tests/api/me-history.test.js
@@ -165,50 +165,6 @@ describe('API /api/me/history', () => {
     });
   });
 
-  it('limits committed history to the latest 20 and loads pending by id', async () => {
-    const uid = 'u-me-history-query-limit';
-    await clearUserState('results', uid);
-
-    await seedParent('results', uid, {
-      attemptCount: 26,
-      pendingAttemptId: 'pending-1',
-    });
-
-    await Promise.all(Array.from({ length: 25 }, async (_, index) => {
-      const createdAt = Timestamp.fromDate(new Date(Date.UTC(2026, 4, index + 1)));
-      await seedAttempt('results', uid, `attempt-${index}`, {
-        status: 'committed',
-        createdAt,
-        summary: { kakuchiiki: `結果 ${index}`, createdAt },
-      });
-    }));
-    const pendingCreatedAt = Timestamp.fromDate(new Date('2026-05-30T00:00:00.000Z'));
-    await seedAttempt('results', uid, 'pending-1', {
-      status: 'pending',
-      createdAt: pendingCreatedAt,
-      summary: { createdAt: pendingCreatedAt },
-    });
-
-    const response = await api.get('/api/me/history?kind=saikaku').set('x-test-uid', uid);
-
-    expect(response.status).toBe(200);
-    expect(response.body.attempts).toHaveLength(20);
-    expect(response.body.attempts.map((attempt) => attempt.id)).toEqual(
-      Array.from({ length: 20 }, (_, index) => `attempt-${24 - index}`),
-    );
-    expect(response.body.attempts.map((attempt) => attempt.id)).not.toContain('attempt-4');
-    expect(response.body.pendingAttempt).toMatchObject({
-      id: 'pending-1',
-      status: 'pending',
-      createdAt: '2026-05-30T00:00:00.000Z',
-    });
-    expect(response.body.summary).toMatchObject({
-      hasPending: true,
-      pendingAttemptId: 'pending-1',
-      isStartBlocked: true,
-    });
-  });
-
   it('returns pendingAttempt and pending summary when parent references a pending attempt', async () => {
     const uid = 'u-me-history-pending';
     await clearUserState('results', uid);


### PR DESCRIPTION
## Summary

PR #41 マージ後、本番で `/api/me/history` が `FAILED_PRECONDITION` で 500 を返し、履歴画面が「読み込みに失敗しました」表示になる障害が発生。原因は `firestore.indexes.json` に追加した複合インデックス `(attempts: status ASC, createdAt DESC)` が本番にデプロイされていなかったため。

Fix #3 の indexed query 最適化を取り消し、`/api/me/history` を元のシンプルな `.get()` + JS 側フィルタ/ソートに戻す。attempts は仕様上ユーザー1人あたり最大 2 (committed) + 1 (pending) の3件で固定なので、indexed query は overengineering だった。これで複合インデックスのデプロイ要件が消える。

## Changes

- `api/me/history.js`: indexed query + pending lookup → 元の `Promise.all(parentRef.get(), attempts.get())` に戻す
- `firestore.indexes.json`: 不要になった `(attempts: status ASC, createdAt DESC)` 複合インデックスを削除
- `tests/api/me-history.test.js`: 該当する 20件 limit テストを削除

## Test plan

- [x] `npm run test:unit` (41 passed)
- [x] `npm run test:api` (41 passed)
- [x] `npm run test:e2e` (6 passed)
- [ ] Vercel preview で履歴画面が読み込めることを確認
- [ ] main マージ後に本番で履歴画面が復旧することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)