### PR TITLE
fix: preserve analysis.saikaku_integration across UAAM redo (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 tests/.env.test
 tests/.env.*
 *.log
+logs/audits/
+logs/migrations/
 .DS_Store
 
 # Firebase local

--- a/api/lib/attempts.js
+++ b/api/lib/attempts.js
@@ -20,6 +20,87 @@ export class ConflictError extends Error {
 const RESERVATION_LOCK_ID = 'reservation';
 const RESERVATION_LOCK_TTL_MS = 10 * 60 * 1000;
 
+/**
+ * @typedef {Object} ProtectedNestedField
+ * @property {string} collection - Firestore collection name (e.g. 'uaam_results')
+ * @property {string} path - Dot-separated path to the protected subfield (e.g. 'analysis.saikaku_integration')
+ */
+
+/**
+ * Sub-fields whose existing values must be preserved across commitAttempt() calls.
+ *
+ * Background: commitAttempt() writes parent docs with tx.set(ref, parentMerge, { merge: true }).
+ * Firestore's { merge: true } only deep-merges TOP-LEVEL fields. Nested map values are replaced
+ * wholesale. So passing parentMerge.analysis = { type_name: 'X' } silently destroys
+ * sibling subfields like analysis.saikaku_integration that were written via field-path notation.
+ *
+ * To prevent regressions, list any nested subfield owned by a different code path here. The
+ * commitAttempt transaction will read the existing value from the parent doc and reinject it
+ * into parentMerge before the set, so the subfield survives.
+ *
+ * @type {ProtectedNestedField[]}
+ */
+const PROTECTED_NESTED_FIELDS = [
+  { collection: 'uaam_results', path: 'analysis.saikaku_integration' },
+  // NOTE: api/analyze.js also writes parentMerge.result on the saikaku side. If a separate code
+  // path ever writes a sub-field of `result.*` for saikaku, add it here to prevent the same bug.
+];
+
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function isObjectMap(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function getByPath(obj, path) {
+  return path.split('.').reduce((current, key) => {
+    if (!isObjectMap(current) || !hasOwn(current, key)) return undefined;
+    return current[key];
+  }, obj);
+}
+
+function setByPath(target, path, value) {
+  const parts = path.split('.');
+  let current = target;
+
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const key = parts[i];
+    current[key] = isObjectMap(current[key]) ? { ...current[key] } : {};
+    current = current[key];
+  }
+
+  current[parts[parts.length - 1]] = value;
+}
+
+function protectNestedFields(collection, parentMerge, existingData) {
+  if (!isObjectMap(parentMerge)) return parentMerge;
+
+  let protectedParentMerge = parentMerge;
+
+  for (const { collection: protectedCollection, path } of PROTECTED_NESTED_FIELDS) {
+    if (protectedCollection !== collection) continue;
+
+    const [topLevelKey] = path.split('.');
+    if (!hasOwn(parentMerge, topLevelKey) || !isObjectMap(parentMerge[topLevelKey])) continue;
+    if (getByPath(parentMerge, path) !== undefined) continue;
+
+    const existingValue = getByPath(existingData, path);
+    if (existingValue === undefined) continue;
+
+    if (protectedParentMerge === parentMerge) {
+      protectedParentMerge = { ...parentMerge };
+    }
+
+    setByPath(protectedParentMerge, path, existingValue);
+  }
+
+  return protectedParentMerge;
+}
+
 function lockExpired(lockData) {
   const acquiredAt = lockData?.acquiredAt;
   if (!acquiredAt) return false;
@@ -95,6 +176,27 @@ export async function reserveAttempt({ collection, uid, kind }) {
   });
 }
 
+/**
+ * Commits a previously-reserved attempt: marks the attempt doc as committed and merges
+ * parentMerge into the parent doc.
+ *
+ * IMPORTANT: parentMerge is written with { merge: true }. Firestore's merge semantics only
+ * deep-merge TOP-LEVEL fields. Any nested map you pass as a value (e.g. parentMerge.analysis)
+ * REPLACES the existing map at that key, dropping sibling subfields.
+ *
+ * If you need to preserve a sibling subfield owned by a different writer (e.g. analysis.saikaku_integration
+ * written by api/integrate.js via field-path notation), add it to PROTECTED_NESTED_FIELDS at the top of
+ * this file. Otherwise it will be silently overwritten on every commit.
+ *
+ * @param {Object} args
+ * @param {string} args.collection
+ * @param {string} args.uid
+ * @param {string} args.attemptId
+ * @param {Object} args.summary
+ * @param {Object} args.full
+ * @param {Object} args.raw
+ * @param {Object} args.parentMerge
+ */
 export async function commitAttempt({ collection, uid, attemptId, summary, full, raw, parentMerge }) {
   const docRef = db.collection(collection).doc(uid);
   const attemptRef = docRef.collection('attempts').doc(attemptId);
@@ -107,6 +209,8 @@ export async function commitAttempt({ collection, uid, attemptId, summary, full,
     if (data.pendingAttemptId !== attemptId) {
       throw new ConflictError('reservation mismatch');
     }
+
+    const protectedParentMerge = protectNestedFields(collection, parentMerge, data);
 
     tx.set(
       attemptRef,
@@ -122,7 +226,7 @@ export async function commitAttempt({ collection, uid, attemptId, summary, full,
     tx.set(
       docRef,
       {
-        ...parentMerge,
+        ...protectedParentMerge,
         pendingAttemptId: null,
         latestAttemptId: attemptId,
         updatedAt: FieldValue.serverTimestamp(),

--- a/scripts/audit-saikaku-integration.mjs
+++ b/scripts/audit-saikaku-integration.mjs
@@ -1,0 +1,216 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import dotenv from 'dotenv';
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore } from 'firebase-admin/firestore';
+
+dotenv.config({ path: '.env.local', quiet: true });
+
+const REQUIRED_ENV = ['FIREBASE_PROJECT_ID', 'FIREBASE_PRIVATE_KEY', 'FIREBASE_CLIENT_EMAIL'];
+const AUDIT_DIR = path.join('logs', 'audits');
+
+function assertProductionEnv() {
+  const emulatorVars = ['FIRESTORE_EMULATOR_HOST', 'FIREBASE_AUTH_EMULATOR_HOST'].filter((key) => process.env[key]);
+  if (emulatorVars.length > 0) {
+    throw new Error(`Refusing to audit while emulator env vars are set: ${emulatorVars.join(', ')}`);
+  }
+
+  const missing = REQUIRED_ENV.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required Firebase Admin env vars: ${missing.join(', ')}. Load .env.local before running this audit.`
+    );
+  }
+}
+
+function initFirebaseAdmin() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      }),
+    });
+  }
+}
+
+function timestampForFile(date = new Date()) {
+  const iso = date.toISOString();
+  return `${iso.slice(0, 10).replaceAll('-', '')}-${iso.slice(11, 19).replaceAll(':', '')}`;
+}
+
+function isNonEmptyPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0;
+}
+
+function optionalText(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function numberOrZero(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return 0;
+}
+
+function toIsoStringOrNull(value) {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value.toDate === 'function') {
+    return value.toDate().toISOString();
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+
+  return null;
+}
+
+function errorSummary(error) {
+  if (!error) {
+    return 'unknown error';
+  }
+
+  const code = typeof error.code === 'string' ? `${error.code}: ` : '';
+  const message = error instanceof Error ? error.message : String(error);
+  return `${code}${message}`;
+}
+
+async function resolveIdentity({ db, auth, uid, data }) {
+  const warnings = [];
+  let name = optionalText(data.name, data.displayName);
+  let email = optionalText(data.email);
+
+  if (!name || !email) {
+    try {
+      const resultsSnap = await db.collection('results').doc(uid).get();
+      if (resultsSnap.exists) {
+        const resultsData = resultsSnap.data() || {};
+        name = name || optionalText(resultsData.name, resultsData.displayName);
+        email = email || optionalText(resultsData.email);
+      }
+    } catch (error) {
+      warnings.push(`results lookup failed: ${errorSummary(error)}`);
+    }
+  }
+
+  if (!name || !email) {
+    try {
+      const user = await auth.getUser(uid);
+      name = name || optionalText(user.displayName);
+      email = email || optionalText(user.email);
+    } catch (error) {
+      warnings.push(`auth lookup failed: ${errorSummary(error)}`);
+    }
+  }
+
+  return { name, email, warnings };
+}
+
+async function buildRecord({ db, auth, docSnap }) {
+  const uid = docSnap.id;
+  const data = docSnap.data() || {};
+  const integration = data.analysis?.saikaku_integration;
+  const hasSaikakuIntegration = data.hasSaikakuIntegration === true;
+  const hasAnalysisIntegration = isNonEmptyPlainObject(integration);
+  const { name, email, warnings } = await resolveIdentity({ db, auth, uid, data });
+
+  const record = {
+    uid,
+    ...(name ? { name } : {}),
+    ...(email ? { email } : {}),
+    hasSaikakuIntegration,
+    hasAnalysisIntegration,
+    integrationUpdatedAt: toIsoStringOrNull(data.integrationUpdatedAt),
+    attemptCount: numberOrZero(data.attemptCount),
+    destroyed: hasSaikakuIntegration && !hasAnalysisIntegration,
+  };
+
+  return { record, warnings };
+}
+
+async function main() {
+  assertProductionEnv();
+  initFirebaseAdmin();
+
+  const db = getFirestore();
+  const auth = getAuth();
+  const snapshot = await db.collection('uaam_results').get();
+  const records = [];
+  let warningCount = 0;
+
+  for (const docSnap of snapshot.docs) {
+    try {
+      const { record, warnings } = await buildRecord({ db, auth, docSnap });
+      records.push(record);
+
+      for (const warning of warnings) {
+        warningCount += 1;
+        console.warn(`[audit-saikaku-integration] ${docSnap.id}: ${warning}`);
+      }
+    } catch (error) {
+      warningCount += 1;
+      console.warn(`[audit-saikaku-integration] ${docSnap.id}: record build failed: ${errorSummary(error)}`);
+      records.push({
+        uid: docSnap.id,
+        hasSaikakuIntegration: false,
+        hasAnalysisIntegration: false,
+        integrationUpdatedAt: null,
+        attemptCount: 0,
+        destroyed: false,
+      });
+    }
+  }
+
+  records.sort((a, b) => a.uid.localeCompare(b.uid));
+
+  await fs.mkdir(AUDIT_DIR, { recursive: true });
+  const outputPath = path.join(AUDIT_DIR, `saikaku-integration-${timestampForFile()}.json`);
+  await fs.writeFile(outputPath, `${JSON.stringify(records, null, 2)}\n`, 'utf8');
+
+  const withFlagCount = records.filter((record) => record.hasSaikakuIntegration).length;
+  const withAnalysisCount = records.filter((record) => record.hasAnalysisIntegration).length;
+  const destroyed = records.filter((record) => record.destroyed);
+  const firstDestroyedUids = destroyed.slice(0, 10).map((record) => record.uid);
+
+  console.log('Saikaku integration audit complete');
+  console.log(`Output: ${outputPath}`);
+  console.log(`Total UAAM users scanned: ${records.length}`);
+  console.log(`hasSaikakuIntegration:true: ${withFlagCount}`);
+  console.log(`hasAnalysisIntegration:true: ${withAnalysisCount}`);
+  console.log(`destroyed: ${destroyed.length}`);
+  console.log(`First 10 destroyed uids: ${firstDestroyedUids.length ? firstDestroyedUids.join(', ') : '(none)'}`);
+
+  if (warningCount > 0) {
+    console.log(`Per-user warnings: ${warningCount}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(`[audit-saikaku-integration] ${errorSummary(error)}`);
+});

--- a/tests/api/saikaku-integration-survives-uaam-redo.test.mjs
+++ b/tests/api/saikaku-integration-survives-uaam-redo.test.mjs
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  let existingParent = {};
+
+  function makeDocRef(path) {
+    return {
+      path,
+      collection(name) {
+        return {
+          doc(id) {
+            return makeDocRef(`${path}/${name}/${id}`);
+          },
+        };
+      },
+    };
+  }
+
+  const tx = {
+    get: vi.fn(async (ref) => ({
+      exists: ref.path === 'uaam_results/user-1',
+      data: () => existingParent,
+    })),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const db = {
+    collection: vi.fn((name) => ({
+      doc(id) {
+        return makeDocRef(`${name}/${id}`);
+      },
+    })),
+    runTransaction: vi.fn(async (callback) => callback(tx)),
+  };
+
+  return {
+    db,
+    tx,
+    setExistingParent(data) {
+      existingParent = data;
+    },
+  };
+});
+
+vi.mock('../../api/lib/firebaseAdmin.js', () => ({
+  db: mocks.db,
+}));
+
+const { commitAttempt } = await import('../../api/lib/attempts.js');
+
+describe('commitAttempt protected nested fields', () => {
+  beforeEach(() => {
+    mocks.db.collection.mockClear();
+    mocks.db.runTransaction.mockClear();
+    mocks.tx.get.mockClear();
+    mocks.tx.set.mockClear();
+    mocks.tx.delete.mockClear();
+  });
+
+  it('preserves analysis.saikaku_integration when a UAAM redo rewrites analysis', async () => {
+    mocks.setExistingParent({
+      pendingAttemptId: 'attempt-2',
+      analysis: {
+        type_name: 'Old UAAM type',
+        saikaku_integration: { foo: 1 },
+      },
+    });
+
+    const parentMerge = {
+      analysis: {
+        type_name: 'New UAAM type',
+        narrative: 'new narrative',
+      },
+    };
+
+    await commitAttempt({
+      collection: 'uaam_results',
+      uid: 'user-1',
+      attemptId: 'attempt-2',
+      summary: { typeName: 'New UAAM type', createdAt: null },
+      full: { result: null, analysis: parentMerge.analysis, scores: null },
+      raw: { input: { answers: {}, vAnswers: {} } },
+      parentMerge,
+    });
+
+    const parentWrite = mocks.tx.set.mock.calls.find(([ref]) => ref.path === 'uaam_results/user-1');
+
+    expect(parentWrite[1].analysis).toEqual({
+      type_name: 'New UAAM type',
+      narrative: 'new narrative',
+      saikaku_integration: { foo: 1 },
+    });
+    expect(parentWrite[2]).toEqual({ merge: true });
+    expect(parentMerge.analysis).toEqual({
+      type_name: 'New UAAM type',
+      narrative: 'new narrative',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- UAAM 2回目 commit で親doc `analysis.saikaku_integration` が消失する regression (#44) を修正
- `commitAttempt` 内のトランザクションで既存値を読み出し parentMerge にマージしてから set
- `PROTECTED_NESTED_FIELDS` 定数で保護対象を allowlist 管理（将来追加が容易）
- 監査スクリプト `scripts/audit-saikaku-integration.mjs` で消失件数を本番計測可能

## Why this happened

Firestore `set({merge:true})` は **top-level field のみ deep-merge** し、nested map を値として渡すと map 全体を置換する仕様（[公式 doc](https://cloud.google.com/firestore/native/docs/manage-data/add-data) で確認）。`api/integrate.js` は `'analysis.saikaku_integration': value` の field-path notation で書いていたが、UAAM の `commitAttempt` は `parentMerge.analysis = { type_name, narrative, ... }` を渡すため、書き込み直前の `saikaku_integration` を黙って捨てていた。

## What changed

### `api/lib/attempts.js`

- `PROTECTED_NESTED_FIELDS` 定数を追加（現在は `uaam_results` の `analysis.saikaku_integration` のみ）
- `protectNestedFields` ヘルパーを追加。トランザクション内で既読の `cur` snapshot から保護パスの既存値を取り出し parentMerge にマージしてから `tx.set` する。**追加 read は発生しない**
- `commitAttempt` の JSDoc に `{merge:true}` の nested map 置換挙動を警告として明記
- 呼び出し側 (`api/uaam.js`, `api/integrate.js`) は変更不要

### `tests/api/saikaku-integration-survives-uaam-redo.test.mjs`

- regression test。Firebase admin を mock して `commitAttempt` の保護動作を検証
- バグがあれば再発検出可能

### `scripts/audit-saikaku-integration.mjs`

- read-only 監査スクリプト
- `hasSaikakuIntegration:true` だが `analysis.saikaku_integration` が空のレコードを抽出
- 出力: `logs/audits/saikaku-integration-{YYYYMMDD-HHmmss}.json`
- 実行: `node --env-file=.env.local scripts/audit-saikaku-integration.mjs`

## Test plan

- [x] `npm test` 全体 green (Test Files 2 passed / Tests 10 passed)
- [x] `npx vitest run --config vitest.config.js tests/api/saikaku-integration-survives-uaam-redo.test.mjs` green
- [x] `node --check scripts/audit-saikaku-integration.mjs` syntax OK
- [x] codex-code-review: REQUEST_CHANGES の指摘は全て **既存コード負債** (`reserveAttempt` の stale pending TTL 不整合、`rollback` 失敗の握り潰し) で本 hotfix のスコープ外。別 issue として切り分け予定
- [ ] **手動 E2E** (本番ステージング):
  1. テストユーザーで UAAM 1回目 → `/api/integrate` 実行 → UAAM 2回目 commit
  2. Firestore Console で `uaam_results/{uid}.analysis.saikaku_integration` が残存していることを確認
  3. デプロイ後 `node --env-file=.env.local scripts/audit-saikaku-integration.mjs` を実行し destroyed 件数を記録（hotfix 後の新規消失は 0 になる想定）

## Follow-up (not in this PR)

codex-code-review が指摘した既存コードの問題（このPRのスコープ外）:

1. `reserveAttempt`: 期限切れロックがあっても `pendingAttemptId` で永久 conflict (stale pending 復旧不能)
2. `rollbackAttempt`: `pendingAttemptId !== attemptId` で無言 return（呼び出し側に失敗が伝わらない）
3. `commitAttempt`: `parentMerge` undefined/null で TypeError（既存挙動と同じ）

これらは別 issue として切り出して個別に修正する。

## Related

- Issue: #44
- Plan: `plans/issue-44-46-saikaku-integration-history.md` (Phase 0 = 本PR)
- Phase 1 (#45) MVP / Phase 2 (#46) per-pair subcollection は別 PR で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)