### PR TITLE
fix(ui): unify history back navigation for #48 #49

### DIFF
--- a/api/uaam.js
+++ b/api/uaam.js
@@ -600,7 +600,16 @@ ${Object.entries(scores.impact.subs).map(([k, v]) => `  ${k}: ${v}/20`).join('\n
       uid: decoded.uid,
       attemptId,
       summary: { typeName: analysis.type_name, createdAt: null },
-      full: { result: null, analysis, scores },
+      full: {
+        result: null,
+        analysis,
+        scores,
+        bias_message: biasMessage,
+        personality_level: personalityLevel,
+        leadership_stage: leadershipStage,
+        three_elements: threeElements,
+        name: decoded.name || '',
+      },
       raw: { input: { answers, vAnswers: vAnswers || {} } },
       parentMerge: {
         uid: decoded.uid,

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -195,3 +195,41 @@ attempts/{aid}[]
 - attempts.js の `reserveAttempt` の stale pending 復旧不能バグ
 - attempts.js の `rollbackAttempt` 重複 rollback 時の負数化
 - クライアント `loading/error/data` 三状態化 (現状は permission error も「データなし」に潰れる)
+
+---
+
+## 7. 履歴戻り導線の統一 — issue #48, #49
+
+### 採用案
+履歴一覧から結果画面に遷移した後、UAAM・才覚の両画面で「← 履歴に戻る」UIを2箇所（タイトル下リンク + フッターボタン）に表示し、戻り先を「最新結果」ではなく「履歴一覧 (`history-saikaku` / `history-uaam`)」に統一。`onReset` prop は通常モードと履歴モードを `selectedAttemptKind` で分岐する既存パターンを保持。
+
+### なぜこうしたか
+1. **遷移の予測可能性**: 履歴一覧→詳細→「戻る」で履歴一覧に戻る、という標準的なナビゲーションを提供。`最新の結果に戻る` だと現在地と異なる文脈に放り出される。
+2. **才覚側既存パターンの再利用**: `ResultScreen.jsx:285-295` の `attemptToResultProps + effectiveResult + isHistoryView` は既に確立済み。UAAM側 (`UAAMResultScreen.jsx`) にも同一構造を導入することで認知負荷を最小化。
+3. **prop 名は変えない (YAGNI)**: 「履歴から戻る用の `onBackToHistory` を別 prop として作る」案は棄却。`onReset` の意味を「閲覧モードを抜ける」に再定義し、App.jsx 側で `selectedAttemptKind` 分岐で吸収する方が現状の単一 prop 構造を維持できる。将来複雑化したら分離リファクタすれば良い。
+
+### UAAM 履歴閲覧モードのクラッシュ防止
+`UAAMResultScreen` は `const { vAnswers, answers } = result` のように `result` を即時分解していたため、`uaamResult=null` 状態で `attemptData` のみを渡される履歴閲覧経路で即時クラッシュしていた。才覚側と同じ `effectiveResult = attemptProps?.result ?? result` パターンを導入し、`!effectiveResult` 時のフォールバックUIも追加。
+
+### attempt.full への UAAM フィールド追加（書き込み + 読み取り両方）
+`bias_message`、`personality_level`、`leadership_stage`、`three_elements`、`name` は従来 `parentMerge` 経由で**親doc のみ** に書かれており、`attempt.full` には入っていなかった。このため履歴詳細表示時にこれらが欠落し、`UAAMResultScreen` が**フォールバック計算**（`assessConfidence`、`determineLeadershipStage` 等）で再構築していた。結果として保存値と表示値がずれる可能性があった。
+
+修正:
+- `api/uaam.js` の `commitAttempt` 呼び出しの `full` に上記5フィールドを追加（新attempts用）
+- `shared/attemptLogic.js` の `legacyDocToAttempt` UAAM 分岐に上記5フィールド + `coach_*` 3フィールドを追加（legacy fallback 用）
+- `src/utils/attemptAdapter.js` の UAAM 分岐で `attempt.full?.<field>` から拾う
+
+`coach_*` フィールド (`coach_confirmed_personality_level` 等) は admin が `AdminScreen` で編集する parent-level の値で attempt 時には存在しない。新attempts時の `commitAttempt` の `full` には入れず、`legacyDocToAttempt` と `attemptAdapter` の読み取り経路でのみ拾う非対称運用。
+
+### `leadership_stage` の正規化（防御的）
+UI (`UAAMResultScreen.jsx:1534`) は `leadershipStage?.stage` を期待するが、過去の保存データに文字列形式 (`'第3段階'` 等) が混入する可能性があるため `attemptAdapter.js` の `normalizeLeadershipStage` で `{ stage: number, name: string }` 形式に統一。
+
+### onReset 分岐の対称化 (App.jsx:401-409, 429-437)
+- 履歴閲覧時 (`selectedAttemptKind === 'uaam'/'saikaku'`): `clearSelectedAttempt()` + `setScreen('history-uaam'|'history-saikaku')`
+- 通常モード (`selectedAttemptKind` null): 従来通り `setUaamResult(null)` + `setScreen('uaam')` / `setResult(null)` + `setScreen('select')`
+
+`uaamResult` / `result` state は履歴閲覧時には消さない（最新結果を戻った後に再表示できるように）。
+
+### スコープ外
+- ブラウザ戻るボタン対応 (issue #50)
+- UAAM 結果画面の巨大化 (2129 行) を分割するリファクタ（codex-code-review 指摘）

--- a/shared/attemptLogic.js
+++ b/shared/attemptLogic.js
@@ -65,6 +65,14 @@ export function legacyDocToAttempt(parentData, kind) {
       result: null,
       analysis: parentData.analysis ?? null,
       scores: parentData.scores ?? null,
+      bias_message: parentData.bias_message ?? null,
+      personality_level: parentData.personality_level ?? null,
+      leadership_stage: parentData.leadership_stage ?? null,
+      three_elements: parentData.three_elements ?? null,
+      name: parentData.name ?? null,
+      coach_confirmed_personality_level: parentData.coach_confirmed_personality_level ?? null,
+      coach_confirmed_leadership_stage: parentData.coach_confirmed_leadership_stage ?? null,
+      coach_observation_note: parentData.coach_observation_note ?? null,
     },
     raw: {
       input: {

--- a/shared/attemptLogic.js
+++ b/shared/attemptLogic.js
@@ -65,7 +65,8 @@ export function legacyDocToAttempt(parentData, kind) {
       result: null,
       analysis: parentData.analysis ?? null,
       scores: parentData.scores ?? null,
-      bias_message: parentData.bias_message ?? null,
+      // bias_message は null（健全）と undefined（未保存）を区別するため `?? null` で潰さない
+      bias_message: parentData.bias_message,
       personality_level: parentData.personality_level ?? null,
       leadership_stage: parentData.leadership_stage ?? null,
       three_elements: parentData.three_elements ?? null,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -401,7 +401,7 @@ export default function App() {
         onReset={() => {
           if (selectedAttemptKind === 'uaam') {
             clearSelectedAttempt();
-            setScreen(uaamResult ? 'uaam-result' : 'uaam');
+            setScreen('history-uaam');
             return;
           }
           setUaamResult(null);
@@ -429,7 +429,7 @@ export default function App() {
         onReset={() => {
           if (selectedAttemptKind === 'saikaku') {
             clearSelectedAttempt();
-            setScreen(result ? 'result' : 'select');
+            setScreen('history-saikaku');
             return;
           }
           setResult(null);

--- a/src/screens/ResultScreen.jsx
+++ b/src/screens/ResultScreen.jsx
@@ -471,7 +471,7 @@ export default function ResultScreen({ user, result, attemptData, isAdmin, onRes
                   textUnderlineOffset: 4,
                 }}
               >
-                最新の結果に戻る
+                ←　履歴に戻る
               </button>
             )}
 
@@ -891,7 +891,7 @@ export default function ResultScreen({ user, result, attemptData, isAdmin, onRes
             transition: 'all 0.3s ease',
           }}
         >
-          {isHistoryView ? '最新の結果に戻る' : 'もう一度解析する'}
+          {isHistoryView ? '←　履歴に戻る' : 'もう一度解析する'}
         </button>
       </div>
 

--- a/src/screens/uaam/UAAMResultScreen.jsx
+++ b/src/screens/uaam/UAAMResultScreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { signOutUser } from '../../firebase';
 import {
   UAAM_AXES,
@@ -21,6 +21,7 @@ import AllPairsTriangle, { SymmetricMatrix } from './AllPairsTriangle';
 import ActivationPanel from '../../ActivationPanel';
 import SaikakuIntegration from './SaikakuIntegration';
 import { normalizeScores } from '../../utils/normalize';
+import { attemptToResultProps } from '../../utils/attemptAdapter';
 
 /* ============================================================
  * 定数
@@ -1775,15 +1776,67 @@ function TalentList({ label, talents, bg, color, textColor, borderStyle = 'solid
 /* ============================================================
  * メインコンポーネント
  * ============================================================ */
-export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdmin, onLogout, onScoresRestored }) {
-  const { vAnswers, answers } = result;
+export default function UAAMResultScreen({ user, result, attemptData, isAdmin, onReset, onAdmin, onLogout, onScoresRestored }) {
+  const attemptProps = useMemo(
+    () => (attemptData ? attemptToResultProps(attemptData, 'uaam') : null),
+    [attemptData],
+  );
+  const effectiveResult = attemptProps?.result ?? result;
+  const isHistoryView = !!attemptData;
+  const normalizedResultScores = useMemo(
+    () => normalizeScores(effectiveResult?.scores) ?? effectiveResult?.scores ?? null,
+    [effectiveResult?.scores],
+  );
+  const vAnswers = effectiveResult?.vAnswers ?? {};
+  const answers = effectiveResult?.answers ?? {};
+  const resultName = effectiveResult?.name ?? user.displayName;
+
   // scores はローカル state で管理（復元時に即時反映）
   // normalizeScores が domainSubs/domainTotal を補完する唯一の場所
-  const [scores, setScores] = useState(() => normalizeScores(result.scores) ?? result.scores);
+  const [scores, setScores] = useState(() => normalizedResultScores);
   // 統合分析は state で管理（バックフィル後に更新できるように）
-  const [analysis, setAnalysis] = useState(result.analysis || null);
+  const [analysis, setAnalysis] = useState(() => effectiveResult?.analysis ?? null);
   const [integrating, setIntegrating] = useState(false);
   const [integrateError, setIntegrateError] = useState('');
+
+  useEffect(() => {
+    setScores(normalizedResultScores);
+  }, [normalizedResultScores]);
+
+  useEffect(() => {
+    setAnalysis(effectiveResult?.analysis ?? null);
+    setIntegrateError('');
+  }, [effectiveResult?.analysis]);
+
+  if (!effectiveResult) {
+    return (
+      <div style={{
+        minHeight: '100vh',
+        background: WHITE,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+      }}>
+        <div style={{ textAlign: 'center' }}>
+          <p style={{ color: TEXT_PRIMARY, fontSize: 15, fontWeight: 700, margin: '0 0 16px' }}>
+            結果データを表示できませんでした
+          </p>
+          <button onClick={onReset} style={{
+            border: `1px solid ${BORDER}`,
+            background: LIGHT_BG,
+            color: TEXT_SECONDARY,
+            borderRadius: 10,
+            padding: '10px 18px',
+            cursor: 'pointer',
+            fontWeight: 700,
+          }}>
+            戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   const runIntegration = async () => {
     setIntegrating(true);
@@ -1814,34 +1867,29 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
   DISPLAY_CROSS = MAX_CROSS / 2;
 
   // 妥当性チェック（V問フラグ判定）── @deprecated 残置
-  const validityResult = (vAnswers && answers) ? checkValidity(vAnswers, answers) : null;
+  const validityResult = (effectiveResult?.vAnswers && effectiveResult?.answers) ? checkValidity(vAnswers, answers) : null;
 
   // 自己評価バイアス（3段階表記・45-95%）── 新方式
-  // result.bias_message があればそれを使い、無ければクライアント側でフォールバック計算
+  // 保存済み bias_message があればそれを使い、無ければクライアント側でフォールバック計算
   const { totalPct: totalPctForBias, minAxisPct, axisSpread } = extractAxisStats(scores);
-  const biasData = result.bias_message !== undefined
-    ? result.bias_message
-    : calculateBiasMessage(vAnswers || {}, totalPctForBias);
+  const biasData = effectiveResult?.bias_message ?? calculateBiasMessage(vAnswers || {}, totalPctForBias);
 
   // Phase 2：人格L＋リーダー段階（推定）。Firestore に保存済みならそれを使い、
   // 無ければクライアント側でフォールバック計算（既存データ下位互換）
-  const personalityLevel = result.personality_level
-    || assessConfidence(determinePersonalityLevel(totalPctForBias, minAxisPct), biasData, axisSpread);
-  const leadershipStage = result.leadership_stage
-    || determineLeadershipStage(totalPctForBias, minAxisPct);
+  const personalityLevel = effectiveResult?.personality_level
+    ?? assessConfidence(determinePersonalityLevel(totalPctForBias, minAxisPct), biasData, axisSpread);
+  const leadershipStage = effectiveResult?.leadership_stage
+    ?? determineLeadershipStage(totalPctForBias, minAxisPct);
   const coachConfirmed = {
-    personality_level: result.coach_confirmed_personality_level,
-    leadership_stage: result.coach_confirmed_leadership_stage,
-    observation_note: result.coach_observation_note,
+    personality_level: effectiveResult?.coach_confirmed_personality_level ?? null,
+    leadership_stage: effectiveResult?.coach_confirmed_leadership_stage ?? null,
+    observation_note: effectiveResult?.coach_observation_note ?? null,
   };
 
   // Phase 3：3要素診断（既存データ下位互換）
   // 國創学方針：3要素は比較しない。スコア + フェーズのみ持つ。
   // 旧フィールド（primary/secondary/weakest/prescription_mode）は保持されてても無視される。
-  const threeElements = (() => {
-    if (result.three_elements && result.three_elements.development_phase) {
-      return result.three_elements;
-    }
+  const threeElements = effectiveResult?.three_elements ?? (() => {
     // フォールバック：scores から動的計算
     const subs = Object.values(scores || {}).reduce((acc, domain) => {
       if (domain?.subs) Object.assign(acc, domain.subs);
@@ -1854,9 +1902,9 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
     };
   })();
 
-  const topType = determineType(scores, analysis);
+  const topType = determineType(scores ?? {}, analysis);
   const subRadars = UAAM_AXES.map(axis => {
-    const subs = scores[axis.key]?.subs || {};
+    const subs = scores?.[axis.key]?.subs || {};
     const order = SUB_ORDER[axis.key];
     return { axis, data: order.map(k => subs[k] || 0), labels: order.map(k => SUB_LABELS[k]), order };
   });
@@ -1929,6 +1977,26 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
       </div>
 
       <div className="pdf-content-wrapper" style={{ maxWidth: 600, margin: '0 auto', padding: '24px 16px' }}>
+        {isHistoryView && (
+          <button
+            onClick={onReset}
+            style={{
+              margin: '0 0 16px',
+              padding: 0,
+              border: 'none',
+              background: 'transparent',
+              color: '#4A6FA5',
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '0.06em',
+              cursor: 'pointer',
+              textDecoration: 'underline',
+              textUnderlineOffset: 4,
+            }}
+          >
+            ←　履歴に戻る
+          </button>
+        )}
 
         {/* ===== 統合プロフィールカード（名前/V問/バイアス/Activation Type/Development Stage） ===== */}
         <ActivationPanel
@@ -1939,7 +2007,7 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
             }, {})
           }
           threshold={13}
-          userName={user.displayName}
+          userName={resultName}
           mode="top"
           vAnswers={vAnswers}
           biasData={biasData}
@@ -2025,14 +2093,35 @@ export default function UAAMResultScreen({ user, result, isAdmin, onReset, onAdm
             旧 V問SVGフラグ・Lv.1-6 バッジ・大型 BiasCard はすべて廃止。 */}
 
         {/* ===== ボタン ===== */}
-        <div className="no-print" style={{ display: 'flex', gap: 12, marginTop: 8, marginBottom: 40 }}>
+        <div className="no-print" style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          marginTop: 8,
+          marginBottom: 40,
+        }}>
           <button onClick={() => window.print()} style={{
-            flex: 1, height: 48, borderRadius: 10, border: 'none',
+            width: '100%', height: 48, borderRadius: 10, border: 'none',
             background: TEXT_PRIMARY, color: WHITE,
             fontSize: 15, fontWeight: 600, cursor: 'pointer',
           }}>
             印刷 / PDF保存
           </button>
+          {isHistoryView && (
+            <button onClick={onReset} style={{
+              width: '100%',
+              height: 48,
+              borderRadius: 10,
+              border: `1px solid ${BORDER}`,
+              background: 'transparent',
+              color: TEXT_SECONDARY,
+              fontSize: 15,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}>
+              ←　履歴に戻る
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/screens/uaam/UAAMResultScreen.jsx
+++ b/src/screens/uaam/UAAMResultScreen.jsx
@@ -1870,9 +1870,12 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
   const validityResult = (effectiveResult?.vAnswers && effectiveResult?.answers) ? checkValidity(vAnswers, answers) : null;
 
   // 自己評価バイアス（3段階表記・45-95%）── 新方式
-  // 保存済み bias_message があればそれを使い、無ければクライアント側でフォールバック計算
+  // 保存済み bias_message があればそれを使う（null は「健全」を意味するので尊重）。
+  // undefined（= 保存されていない超古い legacy データ）のみフォールバック計算する。
   const { totalPct: totalPctForBias, minAxisPct, axisSpread } = extractAxisStats(scores);
-  const biasData = effectiveResult?.bias_message ?? calculateBiasMessage(vAnswers || {}, totalPctForBias);
+  const biasData = effectiveResult?.bias_message !== undefined
+    ? effectiveResult.bias_message
+    : calculateBiasMessage(vAnswers || {}, totalPctForBias);
 
   // Phase 2：人格L＋リーダー段階（推定）。Firestore に保存済みならそれを使い、
   // 無ければクライアント側でフォールバック計算（既存データ下位互換）

--- a/src/screens/uaam/UAAMResultScreen.jsx
+++ b/src/screens/uaam/UAAMResultScreen.jsx
@@ -1889,8 +1889,11 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
   // Phase 3：3要素診断（既存データ下位互換）
   // 國創学方針：3要素は比較しない。スコア + フェーズのみ持つ。
   // 旧フィールド（primary/secondary/weakest/prescription_mode）は保持されてても無視される。
-  const threeElements = effectiveResult?.three_elements ?? (() => {
-    // フォールバック：scores から動的計算
+  const threeElements = (() => {
+    if (effectiveResult?.three_elements && effectiveResult.three_elements.development_phase) {
+      return effectiveResult.three_elements;
+    }
+    // フォールバック：scores から動的計算（旧フィールド primary/secondary/weakest/prescription_mode しか持たない legacy データもこちら）
     const subs = Object.values(scores || {}).reduce((acc, domain) => {
       if (domain?.subs) Object.assign(acc, domain.subs);
       return acc;

--- a/src/utils/attemptAdapter.js
+++ b/src/utils/attemptAdapter.js
@@ -30,7 +30,9 @@ export function attemptToResultProps(attempt, kind) {
       answers: attempt.raw?.input?.answers ?? {},
       vAnswers: attempt.raw?.input?.vAnswers ?? {},
       name: attempt.full?.name ?? null,
-      bias_message: attempt.full?.bias_message ?? null,
+      // bias_message は null（= 健全、表示なし）と undefined（= 未保存 legacy、要再計算）を
+      // UI 側で区別する。`?? null` で潰すと健全の null と legacy の undefined を区別できなくなる。
+      bias_message: attempt.full?.bias_message,
       personality_level: attempt.full?.personality_level ?? null,
       leadership_stage: normalizeLeadershipStage(attempt.full?.leadership_stage),
       three_elements: attempt.full?.three_elements ?? null,

--- a/src/utils/attemptAdapter.js
+++ b/src/utils/attemptAdapter.js
@@ -35,7 +35,8 @@ export function attemptToResultProps(attempt, kind) {
       leadership_stage: normalizeLeadershipStage(attempt.full?.leadership_stage),
       three_elements: attempt.full?.three_elements ?? null,
       coach_confirmed_personality_level: attempt.full?.coach_confirmed_personality_level ?? null,
-      coach_confirmed_leadership_stage: normalizeLeadershipStage(attempt.full?.coach_confirmed_leadership_stage),
+      // ActivationPanel が `第${coachConfirmed.leadership_stage}` のように scalar として参照するため正規化しない
+      coach_confirmed_leadership_stage: attempt.full?.coach_confirmed_leadership_stage ?? null,
       coach_observation_note: attempt.full?.coach_observation_note ?? null,
     },
   };

--- a/src/utils/attemptAdapter.js
+++ b/src/utils/attemptAdapter.js
@@ -1,5 +1,13 @@
 export { legacyDocToAttempt } from '../../shared/attemptLogic.js';
 
+function normalizeLeadershipStage(value) {
+  if (!value) return null;
+  if (typeof value === 'object') return value;
+  const match = String(value).match(/\d+/);
+  const stage = match ? Number(match[0]) : 1;
+  return { stage, name: String(value) };
+}
+
 export function attemptToResultProps(attempt, kind) {
   if (!attempt) return null;
 
@@ -21,6 +29,14 @@ export function attemptToResultProps(attempt, kind) {
       analysis: attempt.full?.analysis ?? null,
       answers: attempt.raw?.input?.answers ?? {},
       vAnswers: attempt.raw?.input?.vAnswers ?? {},
+      name: attempt.full?.name ?? null,
+      bias_message: attempt.full?.bias_message ?? null,
+      personality_level: attempt.full?.personality_level ?? null,
+      leadership_stage: normalizeLeadershipStage(attempt.full?.leadership_stage),
+      three_elements: attempt.full?.three_elements ?? null,
+      coach_confirmed_personality_level: attempt.full?.coach_confirmed_personality_level ?? null,
+      coach_confirmed_leadership_stage: normalizeLeadershipStage(attempt.full?.coach_confirmed_leadership_stage),
+      coach_observation_note: attempt.full?.coach_observation_note ?? null,
     },
   };
 }

--- a/tests/e2e/_helpers.js
+++ b/tests/e2e/_helpers.js
@@ -130,6 +130,91 @@ export function saikakuAttempt() {
   };
 }
 
+export function uaamParent(attemptCount = 1) {
+  const result = uaamResult();
+  return {
+    attemptCount,
+    pendingAttemptId: null,
+    latestAttemptId: 'attempt-1',
+    scores: result.scores,
+    analysis: result.analysis,
+    bias_message: result.bias_message,
+    personality_level: result.personality_level,
+    leadership_stage: result.leadership_stage,
+    three_elements: result.three_elements,
+    name: result.name,
+    email: '',
+    photoURL: '',
+    answers: uaamAnswers(),
+    vAnswers: uaamVAnswers(),
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+  };
+}
+
+export function uaamAttempt(overrides = {}) {
+  const result = uaamResult();
+  return {
+    status: 'committed',
+    createdAt: Timestamp.now(),
+    summary: {
+      typeName: 'E2Eタイプ',
+      createdAt: Timestamp.now(),
+    },
+    full: {
+      result: null,
+      analysis: result.analysis,
+      scores: result.scores,
+      bias_message: result.bias_message,
+      personality_level: result.personality_level,
+      leadership_stage: result.leadership_stage,
+      three_elements: result.three_elements,
+      name: result.name,
+    },
+    raw: {
+      input: {
+        answers: uaamAnswers(),
+        vAnswers: uaamVAnswers(),
+      },
+    },
+    ...overrides,
+  };
+}
+
+export function uaamResult() {
+  return {
+    scores: {
+      mindset: uaamAxisScore(['meaning', 'mindfulness', 'mindshift', 'mastery']),
+      literacy: uaamAxisScore(['learning', 'logical', 'life', 'leadership']),
+      competency: uaamAxisScore(['critical', 'creativity', 'communication', 'collaboration']),
+      impact: uaamAxisScore(['idea', 'innovation', 'implementation', 'influence']),
+    },
+    analysis: {
+      type_name: 'E2Eタイプ',
+      narrative: 'E2Eテスト用ナラティブ',
+      axis_analysis: {
+        mindset: 'a',
+        literacy: 'a',
+        competency: 'a',
+        impact: 'a',
+      },
+      strengths: ['s'],
+      growth_areas: ['g'],
+      action_suggestions: ['x'],
+    },
+    bias_message: null,
+    personality_level: { level: 'L4', name: '自律型', confidence: 'medium', signals: [] },
+    leadership_stage: { stage: 3, name: '自律' },
+    three_elements: {
+      leadership: 60,
+      teamBuilding: 55,
+      management: 50,
+      development_phase: 'phase-2',
+    },
+    name: 'E2E User',
+  };
+}
+
 export function pendingAttempt(createdAtOffsetMs = 0) {
   const createdAt = Timestamp.fromMillis(Date.now() + createdAtOffsetMs);
   return {
@@ -139,6 +224,30 @@ export function pendingAttempt(createdAtOffsetMs = 0) {
     summary: { createdAt },
     full: null,
     raw: { input: {} },
+  };
+}
+
+function uaamAxisScore(subKeys) {
+  const subs = Object.fromEntries(subKeys.map((key) => [key, 15]));
+  return {
+    total: 60,
+    max: 80,
+    percentage: 75,
+    subs,
+    domainSubs: { ...subs },
+    domainTotal: 60,
+  };
+}
+
+function uaamAnswers() {
+  return Object.fromEntries(Array.from({ length: 64 }, (_, i) => [String(i + 1), 4]));
+}
+
+function uaamVAnswers() {
+  return {
+    V1: 3,
+    V2: 3,
+    V3: 3,
   };
 }
 

--- a/tests/e2e/history-flow.spec.js
+++ b/tests/e2e/history-flow.spec.js
@@ -19,8 +19,9 @@ test('history list to detail and back', async ({ page }) => {
   await page.getByTestId('history-item').first().click();
 
   await expect(page.getByText('問いに火を灯す人').first()).toBeVisible();
-  await page.getByRole('button', { name: '最新の結果に戻る' }).first().click();
-  await expect(page.getByText('才覚解読プログラム')).toBeVisible();
+  await page.getByRole('button', { name: /履歴に戻る/ }).first().click();
+  await expect(page.getByTestId('history-item')).toHaveCount(1);
+  await expect(page.getByRole('heading', { name: '才覚領域' })).toBeVisible();
 });
 
 test('pending residue shows notice without increasing history count', async ({ page }) => {

--- a/tests/e2e/uaam-history-flow.spec.js
+++ b/tests/e2e/uaam-history-flow.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { clearUser, createAuthUser, loginAs, seedUser, uaamAttempt, uaamParent } from './_helpers.js';
+
+test('uaam history list to detail and back', async ({ page }) => {
+  const email = `e2e-uaam-history-${Date.now()}@example.com`;
+  const password = 'password123';
+  const user = await createAuthUser(email, password);
+  await clearUser(user.uid);
+  await seedUser(user.uid, 'uaam', {
+    parent: uaamParent(1),
+    attempts: { 'attempt-1': uaamAttempt() },
+  });
+
+  await loginAs(page, email, password);
+  await expect(page.getByTestId('history-link-uaam')).toContainText('履歴を見る (1)', { timeout: 15000 });
+  await page.getByTestId('history-link-uaam').click();
+
+  await expect(page.getByTestId('history-item')).toHaveCount(1);
+  await page.getByTestId('history-item').first().click();
+
+  await expect(page.getByText('Unique Ability Activation Matrix').first()).toBeVisible();
+  await page.getByRole('button', { name: /履歴に戻る/ }).first().click();
+  await expect(page.getByTestId('history-item')).toHaveCount(1);
+  await expect(page.getByRole('heading', { name: '才覚発動領域 MATRIX' })).toBeVisible();
+});

--- a/tests/unit/adapter.test.js
+++ b/tests/unit/adapter.test.js
@@ -31,6 +31,14 @@ describe('attemptAdapter', () => {
       full: {
         scores: { mindset: { total: 60 } },
         analysis: { type_name: '実装する案内人' },
+        name: '山田太郎',
+        bias_message: { level: 'moderate' },
+        personality_level: { level: 4 },
+        leadership_stage: { stage: 3 },
+        three_elements: { development_phase: 'strength_focus' },
+        coach_confirmed_personality_level: { level: 5 },
+        coach_confirmed_leadership_stage: { stage: 4 },
+        coach_observation_note: '観察メモ',
       },
       raw: {
         input: {
@@ -46,6 +54,14 @@ describe('attemptAdapter', () => {
         analysis: { type_name: '実装する案内人' },
         answers: { 1: 3 },
         vAnswers: { V1: 4 },
+        name: '山田太郎',
+        bias_message: { level: 'moderate' },
+        personality_level: { level: 4 },
+        leadership_stage: { stage: 3 },
+        three_elements: { development_phase: 'strength_focus' },
+        coach_confirmed_personality_level: { level: 5 },
+        coach_confirmed_leadership_stage: { stage: 4 },
+        coach_observation_note: '観察メモ',
       },
     });
   });

--- a/tests/unit/adapter.test.js
+++ b/tests/unit/adapter.test.js
@@ -27,17 +27,22 @@ describe('attemptAdapter', () => {
   });
 
   it('maps a uaam attempt to UAAMResultScreen props', () => {
+    // Consumer contracts (確認済み):
+    //   personality_level: object { level, name, confidence, signals } — UAAMResultScreen が ?.level/.name 参照
+    //   coach_confirmed_personality_level: string scalar 'L5' — ActivationPanel:468-470 で .replace('L', '')
+    //   leadership_stage: object { stage, name } — UAAMResultScreen:1534 で ?.stage 参照
+    //   coach_confirmed_leadership_stage: number scalar 4 — ActivationPanel:480-482 で `第${...}`/(... - 1)
     const attempt = {
       full: {
         scores: { mindset: { total: 60 } },
         analysis: { type_name: '実装する案内人' },
         name: '山田太郎',
         bias_message: { level: 'moderate' },
-        personality_level: { level: 4 },
-        leadership_stage: { stage: 3 },
+        personality_level: { level: 'L4', name: '自律型', confidence: 'medium' },
+        leadership_stage: { stage: 3, name: '自律' },
         three_elements: { development_phase: 'strength_focus' },
-        coach_confirmed_personality_level: { level: 5 },
-        coach_confirmed_leadership_stage: { stage: 4 },
+        coach_confirmed_personality_level: 'L5',
+        coach_confirmed_leadership_stage: 4,
         coach_observation_note: '観察メモ',
       },
       raw: {
@@ -56,13 +61,56 @@ describe('attemptAdapter', () => {
         vAnswers: { V1: 4 },
         name: '山田太郎',
         bias_message: { level: 'moderate' },
-        personality_level: { level: 4 },
-        leadership_stage: { stage: 3 },
+        personality_level: { level: 'L4', name: '自律型', confidence: 'medium' },
+        leadership_stage: { stage: 3, name: '自律' },
         three_elements: { development_phase: 'strength_focus' },
-        coach_confirmed_personality_level: { level: 5 },
-        coach_confirmed_leadership_stage: { stage: 4 },
+        coach_confirmed_personality_level: 'L5',
+        coach_confirmed_leadership_stage: 4,
         coach_observation_note: '観察メモ',
       },
     });
+  });
+
+  it('preserves null bias_message as the saved "healthy" signal (UAAM)', () => {
+    // bias_message: null は「自己評価バイアスなし＝健全」を意味する保存値で、
+    // UI 側で fallback 計算に流してはいけない。
+    const attempt = {
+      full: { scores: {}, analysis: null, bias_message: null },
+      raw: { input: {} },
+    };
+    const out = attemptToResultProps(attempt, 'uaam');
+    expect(out.result.bias_message).toBeNull();
+  });
+
+  it('leaves bias_message undefined when not stored (UAAM legacy)', () => {
+    // 古い committedAttempt は bias_message を保存していない (key 自体が無い)。
+    // adapter が ?? null で潰すと UI 側で「未保存」と「健全」の区別がつかなくなる。
+    const attempt = {
+      full: { scores: {}, analysis: null }, // bias_message 不在
+      raw: { input: {} },
+    };
+    const out = attemptToResultProps(attempt, 'uaam');
+    expect(out.result.bias_message).toBeUndefined();
+  });
+
+  it('normalizes string leadership_stage but keeps coach scalar fields raw (UAAM)', () => {
+    // leadership_stage: object { stage, name } を期待する UAAMResultScreen.jsx:1534 のため、
+    // 文字列形式 '第3段階' は normalize する。
+    // 一方 coach_confirmed_leadership_stage は ActivationPanel:480-482 が `第${...}` と算術で
+    // scalar を期待するため正規化しない。
+    const attempt = {
+      full: {
+        scores: {},
+        analysis: null,
+        leadership_stage: '第3段階',
+        coach_confirmed_leadership_stage: 4,
+        coach_confirmed_personality_level: 'L5',
+      },
+      raw: { input: {} },
+    };
+    const out = attemptToResultProps(attempt, 'uaam');
+    expect(out.result.leadership_stage).toEqual({ stage: 3, name: '第3段階' });
+    expect(out.result.coach_confirmed_leadership_stage).toBe(4);
+    expect(out.result.coach_confirmed_personality_level).toBe('L5');
   });
 });


### PR DESCRIPTION
## Summary
- 履歴一覧から結果画面に遷移した後、UAAM・才覚の両画面で「← 履歴に戻る」UI を2箇所（タイトル下 + フッター）に統一表示
- 戻り先を「最新結果」ではなく「履歴一覧 (`history-saikaku` / `history-uaam`)」に統一
- UAAMResultScreen の即時 `result` 分解によるクラッシュを防止（才覚側と同じ `effectiveResult` パターン導入）
- attempt.full に UAAM メタフィールドを書き込み・読み取り両方で追加。履歴詳細時にフォールバック計算でなく保存値を表示

Closes #48
Closes #49

## 主な変更
| ファイル | 変更点 |
|---|---|
| `src/screens/ResultScreen.jsx` | 「最新の結果に戻る」→「←　履歴に戻る」(2箇所) |
| `src/screens/uaam/UAAMResultScreen.jsx` | attemptData prop + effectiveResult + 履歴に戻るボタン2箇所 + 異常系UI |
| `src/App.jsx` | onReset の `selectedAttemptKind` 分岐で `history-*` 画面へ |
| `api/uaam.js` | commitAttempt の full に `bias_message` / `personality_level` / `leadership_stage` / `three_elements` / `name` を追加 |
| `shared/attemptLogic.js` | legacyDocToAttempt UAAM 分岐に上記 + `coach_*` 3 フィールド |
| `src/utils/attemptAdapter.js` | UAAM 分岐で `attempt.full` から拾う + `leadership_stage` 正規化 |
| `tests/e2e/_helpers.js` | UAAM seed helpers (`uaamParent`/`uaamAttempt`/`uaamResult`) 追加 |
| `tests/e2e/history-flow.spec.js` | 新ラベル + 戻り先 (history list) アサート |
| `tests/e2e/uaam-history-flow.spec.js` | 新規 UAAM 履歴 E2E |
| `tests/unit/adapter.test.js` | 拡張 UAAM shape に追従 |
| `docs/design-rationale.md` | §7 履歴戻り導線統一の設計判断 |

## Test plan
- [x] `npm test` (vitest) — 2 files, 10 tests pass
- [x] `npm run test:unit` — 6 files, 41 tests pass
- [x] `npm run build` — production build pass
- [x] `npm run test:e2e` — Firebase emulator (auth:9099, firestore:8080) + API (3001) + Vite (5173) 環境で全 7 テスト pass (badge / history×2 / limit / modern-user / pending-block / uaam-history)
- [x] `/codex-code-review` で 8 観点並列レビュー実行（PR起因の指摘 = leadership_stage 型ズレ + 64問数 を修正済み、その他 High は既存コードベースの pre-existing 問題で別 issue 扱い）

## スコープ外（フォロー）
- ブラウザ戻るボタン対応（issue #50）
- UAAM 結果画面 (2129 行) の分割リファクタ
- UAAM 診断ロジックの API/UI 共有化（codex-code-review High 指摘、別 issue 推奨）

🤖 Generated with [Claude Code](https://claude.com/claude-code)