### PR TITLE
fix(ui): SelectScreen ボタン整列・ロック位置・履歴メタ余白の調整 (#47)

### DIFF
--- a/src/screens/SelectScreen.jsx
+++ b/src/screens/SelectScreen.jsx
@@ -133,10 +133,8 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
 
   const renderHistoryArea = (count, hasPending) => {
     const hasVisibleMeta = status !== null && (hasPending || count >= 2);
+    if (!hasVisibleMeta) return null;
     const metaText = hasPending ? '処理中…' : '診断は最大2回まで実施済み';
-
-    // Meta-info area is fixed-height in all states to prevent layout jump (issue #47, Round 1 debate)
-    // 28px fits the 11px single-line max-count and pending messages while keeping the card compact.
     return (
       <div style={{
         display: 'flex',
@@ -146,19 +144,15 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
         marginTop: 8,
         pointerEvents: 'none',
       }}>
-        <span
-          aria-hidden={hasVisibleMeta ? undefined : 'true'}
-          style={{
-            visibility: hasVisibleMeta ? 'visible' : 'hidden',
-            color: '#8A8070',
-            fontSize: 11,
-            fontWeight: hasPending ? 700 : 600,
-            letterSpacing: '0.04em',
-            lineHeight: '16px',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {hasVisibleMeta ? metaText : '\u00A0'}
+        <span style={{
+          color: '#8A8070',
+          fontSize: 11,
+          fontWeight: hasPending ? 700 : 600,
+          letterSpacing: '0.04em',
+          lineHeight: '16px',
+          whiteSpace: 'nowrap',
+        }}>
+          {metaText}
         </span>
       </div>
     );
@@ -409,16 +403,17 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
                   height: 36,
                   padding: '0 16px',
                   border: 'none',
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: '#1A1610',
+                  letterSpacing: '0.05em',
                   lineHeight: 1,
                   transition: 'background 0.3s ease',
                   fontFamily: 'inherit',
                   pointerEvents: 'none',
                 }}>
-                <span style={{ fontSize: 12, fontWeight: 700, color: '#1A1610', letterSpacing: '0.05em' }}>
-                  診断を開始する
-                </span>
+                診断を開始する
                 <span style={{
-                  fontSize: 12, fontWeight: 700, color: '#1A1610',
                   transform: hoverSaikaku ? 'translateX(3px)' : 'translateX(0)',
                   transition: 'transform 0.3s ease',
                   display: 'inline-block',
@@ -553,16 +548,17 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
                   height: 36,
                   padding: '0 16px',
                   border: 'none',
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: '#F5F0E8',
+                  letterSpacing: '0.05em',
                   lineHeight: 1,
                   transition: 'background 0.3s ease',
                   fontFamily: 'inherit',
                   pointerEvents: 'none',
                 }}>
-                <span style={{ fontSize: 12, fontWeight: 700, color: '#F5F0E8', letterSpacing: '0.05em' }}>
-                  診断を開始する
-                </span>
+                診断を開始する
                 <span style={{
-                  fontSize: 12, fontWeight: 700, color: '#F5F0E8',
                   transform: hoverUaam ? 'translateX(3px)' : 'translateX(0)',
                   transition: 'transform 0.3s ease',
                   display: 'inline-block',
@@ -575,8 +571,8 @@ export default function SelectScreen({ user, isAdmin, onSelectSaikaku, onSelectU
               }, hoverUaamHistory, setHoverUaamHistory)}
               <div style={{
                 display: 'flex', alignItems: 'center', gap: 5,
+                height: 36,
                 fontSize: 11, color: 'rgba(107,154,212,0.5)', fontWeight: 500,
-                marginLeft: 'auto',
                 position: 'relative',
                 zIndex: 2,
                 pointerEvents: 'none',


### PR DESCRIPTION
## Summary

つかさからの追加指摘 3 点を一括対応。

### 1. CTA「診断を開始する」と「履歴を見る」のテキスト位置の不揃い
- **原因**: CTA は `<div><span>テキスト</span><span>→</span></div>` のネスト span 構造、履歴ボタンは `<button>テキスト</button>` の単純構造。inline-flex 内での line-box 計算が異なり、垂直方向に 1-2px のサブピクセルずれが発生
- **修正**: CTA の font プロパティ（fontSize/fontWeight/color/letterSpacing）を outer div に集約し、テキストを直接の子ノードに。矢印 span は transform/transition のみ保持。これで両ボタンの「flex container 内に直接テキスト」構造が揃い、レンダリングが一致

### 2. ボタン下の空き地（旧 renderHistoryArea）
- **原因**: 履歴ボタンが下段から CTA と横並びに移動した後も、メタ情報用に 28+8=36px の領域を `visibility:hidden` で常時確保していた
- **修正**: `hasVisibleMeta` が `false`（pending でも count>=2 でもない）の場合は `null` を返すよう変更。pending / max-count 時のみ 36px を確保するので、通常状態の余白が消える。状態遷移時のレイアウトジャンプは発生するが、ユーザー操作の節目なので許容範囲

### 3. UAAM のパスワードロックアイコンが孤立行に折り返す
- **原因**: `marginLeft: 'auto'` でカード右端へ飛ばし、`flexWrap: 'wrap'` で狭幅時に折り返す設計だった。CTA 横並び化と相まって、ロックだけが新しい行で寂しく見えていた
- **修正**: `marginLeft: 'auto'` を撤去し `height: 36` を付与。CTA → 履歴 → ロック の順で同じ行に並ぶ。狭幅で折り返しても CTA 群の直後に来るので「パスワード必要」の意味的近接が保たれる

## Test plan

- [x] `pnpm test:unit`: 67/67 pass
- [ ] **視覚確認**：dev / preview で両カードを開き、CTA と履歴ボタンの高さ・テキスト位置が揃っていること
- [ ] **メタ情報の確認**：count=1（メタなし）→ count=2 / pending（メタあり）への遷移でジャンプが許容範囲であること
- [ ] **UAAM ロック位置の確認**：CTA → 履歴 → ロック が同列。狭幅時の折り返しが自然なこと

## Files

- `src/screens/SelectScreen.jsx` — CTA 構造のフラット化、`renderHistoryArea` の条件付きレンダリング、UAAM ロック位置調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)