### PR TITLE
fix(coaching): 履歴からもコーチング回答を編集・保存できるようにする (#69)

### DIFF
--- a/src/screens/uaam/SaikakuIntegration.jsx
+++ b/src/screens/uaam/SaikakuIntegration.jsx
@@ -324,7 +324,7 @@ export default function SaikakuIntegration({
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const [draftAnswers, setDraftAnswers] = useState([]);
-  const [dirtyByQuestion, setDirtyByQuestion] = useState(() => new Set());
+  const [dirtyByQuestion, setDirtyByQuestion] = useState(() => new Map());
   const [saveError, setSaveError] = useState('');
   const coachingQuestions = useMemo(
     () => (Array.isArray(integration?.coaching_questions) ? integration.coaching_questions : []),
@@ -346,7 +346,9 @@ export default function SaikakuIntegration({
         // 末尾`？`違い・全角半角空白・NFKC 互換差を吸収する（issue #62 設計の本質）。
         const normalizedCurrent = normalizeQuestionText(questionText);
         if (!normalizedCurrent) return '';
-        if (dirtyByQuestion.has(normalizedCurrent)) return prev[i] || '';
+        if (dirtyByQuestion.has(normalizedCurrent)) {
+          return dirtyByQuestion.get(normalizedCurrent) ?? '';
+        }
         const saved = answerEntries.find((entry) => {
           const normalizedSaved = normalizeQuestionText(entry?.questionText);
           return normalizedSaved !== null && normalizedSaved === normalizedCurrent;
@@ -363,8 +365,8 @@ export default function SaikakuIntegration({
     const normalizedKey = normalizeQuestionText(coachingQuestions[index]);
     if (normalizedKey) {
       setDirtyByQuestion((prev) => {
-        const next = new Set(prev);
-        next.add(normalizedKey);
+        const next = new Map(prev);
+        next.set(normalizedKey, value);
         return next;
       });
     }
@@ -389,7 +391,7 @@ export default function SaikakuIntegration({
 
     try {
       await onSave(items);
-      setDirtyByQuestion(new Set());
+      setDirtyByQuestion(new Map());
       onDirtyChange?.(false);
     } catch (e) {
       setSaveError(e?.message || '回答を保存できませんでした。再度お試しください。');

--- a/src/screens/uaam/SaikakuIntegration.jsx
+++ b/src/screens/uaam/SaikakuIntegration.jsx
@@ -364,9 +364,19 @@ export default function SaikakuIntegration({
   const updateDraftAnswer = (index, value) => {
     const normalizedKey = normalizeQuestionText(coachingQuestions[index]);
     if (normalizedKey) {
+      const savedEntry = answerEntries.find((entry) => {
+        const normalizedSaved = normalizeQuestionText(entry?.questionText);
+        return normalizedSaved !== null && normalizedSaved === normalizedKey;
+      });
+      const savedAnswer = typeof savedEntry?.answer === 'string' ? savedEntry.answer : '';
+
       setDirtyByQuestion((prev) => {
         const next = new Map(prev);
-        next.set(normalizedKey, value);
+        if (value === savedAnswer) {
+          next.delete(normalizedKey);
+        } else {
+          next.set(normalizedKey, value);
+        }
         return next;
       });
     }

--- a/src/screens/uaam/SaikakuIntegration.jsx
+++ b/src/screens/uaam/SaikakuIntegration.jsx
@@ -320,6 +320,7 @@ export default function SaikakuIntegration({
   status,
   defaultOpen = false,
   readOnly = false,
+  onDirtyChange,
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const [draftAnswers, setDraftAnswers] = useState([]);
@@ -332,22 +333,30 @@ export default function SaikakuIntegration({
   const answerEntries = useMemo(() => Object.values(answersMap || {}), [answersMap]);
   const savedTime = useMemo(() => formatSavedTime(lastSavedAt), [lastSavedAt]);
   const hasDraftAnswer = coachingQuestions.some((_, i) => (draftAnswers[i] || '').trim().length > 0);
-  // readOnly 時は保存させない（履歴 attempt 表示など）
-  const canSave = !readOnly && !!onSave && !saving && hasDraftAnswer;
+  const canSave = !!onSave && !saving && hasDraftAnswer;
 
   useEffect(() => {
-    setDraftAnswers((prev) => coachingQuestions.map((questionText, i) => {
-      // normalize同士で照合 — server側 sha1(normalize(text)) と等価のqid マッチ。
-      // 末尾`？`違い・全角半角空白・NFKC 互換差を吸収する（issue #62 設計の本質）。
-      const normalizedCurrent = normalizeQuestionText(questionText);
-      if (!normalizedCurrent) return '';
-      if (dirtyByQuestion.has(normalizedCurrent)) return prev[i] || '';
-      const saved = answerEntries.find((entry) => {
-        const normalizedSaved = normalizeQuestionText(entry?.questionText);
-        return normalizedSaved !== null && normalizedSaved === normalizedCurrent;
+    onDirtyChange?.(dirtyByQuestion.size > 0);
+  }, [dirtyByQuestion, onDirtyChange]);
+
+  useEffect(() => {
+    setDraftAnswers((prev) => {
+      const next = coachingQuestions.map((questionText, i) => {
+        // normalize同士で照合 — server側 sha1(normalize(text)) と等価のqid マッチ。
+        // 末尾`？`違い・全角半角空白・NFKC 互換差を吸収する（issue #62 設計の本質）。
+        const normalizedCurrent = normalizeQuestionText(questionText);
+        if (!normalizedCurrent) return '';
+        if (dirtyByQuestion.has(normalizedCurrent)) return prev[i] || '';
+        const saved = answerEntries.find((entry) => {
+          const normalizedSaved = normalizeQuestionText(entry?.questionText);
+          return normalizedSaved !== null && normalizedSaved === normalizedCurrent;
+        });
+        return typeof saved?.answer === 'string' ? saved.answer : '';
       });
-      return typeof saved?.answer === 'string' ? saved.answer : '';
-    }));
+      const unchanged = next.length === prev.length
+        && next.every((value, index) => value === prev[index]);
+      return unchanged ? prev : next;
+    });
   }, [answerEntries, coachingQuestions, dirtyByQuestion]);
 
   const updateDraftAnswer = (index, value) => {
@@ -380,6 +389,8 @@ export default function SaikakuIntegration({
 
     try {
       await onSave(items);
+      setDirtyByQuestion(new Set());
+      onDirtyChange?.(false);
     } catch (e) {
       setSaveError(e?.message || '回答を保存できませんでした。再度お試しください。');
     }
@@ -624,104 +635,78 @@ export default function SaikakuIntegration({
                       <div style={{ fontSize: 13, color: P.text, lineHeight: 1.7, paddingTop: 1,
                         fontFamily: "'Noto Serif JP', serif" }}>{toJP(q)}</div>
                     </div>
-                    {!readOnly ? (
-                      <textarea
-                        value={draft}
-                        onChange={(e) => updateDraftAnswer(i, e.target.value)}
-                        disabled={saving}
-                        rows={3}
-                        maxLength={2000}
-                        placeholder="あなたの考えを書いてみてください"
-                        style={{
-                          width: '100%',
-                          boxSizing: 'border-box',
-                          minHeight: 88,
-                          padding: '10px 12px',
-                          border: `1px solid ${P.border}`,
-                          borderRadius: 8,
-                          background: saving ? '#F7F3EC' : P.surface,
-                          color: P.text,
-                          fontSize: 13,
-                          lineHeight: 1.7,
-                          fontFamily: "'Noto Serif JP', serif",
-                          resize: 'vertical',
-                          outlineOffset: 2,
-                          opacity: saving ? 0.72 : 1,
-                        }}
-                      />
-                    ) : (
-                      <div
-                        style={{
-                          width: '100%',
-                          boxSizing: 'border-box',
-                          minHeight: 56,
-                          padding: '10px 12px',
-                          border: `1px dashed ${P.border}`,
-                          borderRadius: 8,
-                          background: P.bg,
-                          color: draft ? P.text : P.muted,
-                          fontSize: 13,
-                          lineHeight: 1.7,
-                          fontFamily: "'Noto Serif JP', serif",
-                          whiteSpace: 'pre-wrap',
-                          fontStyle: draft ? 'normal' : 'italic',
-                        }}
-                      >
-                        {draft || '（未回答）'}
-                      </div>
-                    )}
+                    <textarea
+                      value={draft}
+                      onChange={(e) => updateDraftAnswer(i, e.target.value)}
+                      disabled={saving}
+                      rows={3}
+                      maxLength={2000}
+                      placeholder="あなたの考えを書いてみてください"
+                      style={{
+                        width: '100%',
+                        boxSizing: 'border-box',
+                        minHeight: 88,
+                        padding: '10px 12px',
+                        border: `1px solid ${P.border}`,
+                        borderRadius: 8,
+                        background: saving ? '#F7F3EC' : P.surface,
+                        color: P.text,
+                        fontSize: 13,
+                        lineHeight: 1.7,
+                        fontFamily: "'Noto Serif JP', serif",
+                        resize: 'vertical',
+                        outlineOffset: 2,
+                        opacity: saving ? 0.72 : 1,
+                      }}
+                    />
                   </div>
                 );
               })}
-              {!readOnly && (
-                <>
-                  <button
-                    type="button"
-                    onClick={handleSaveDrafts}
-                    disabled={!canSave}
-                    style={{
-                      width: '100%',
-                      marginTop: 2,
-                      padding: '12px 16px',
-                      border: 'none',
-                      borderRadius: 8,
-                      background: canSave
-                        ? `linear-gradient(135deg, ${P.gold} 0%, ${P.goldDim} 100%)`
-                        : P.border,
-                      color: canSave ? '#fff' : P.muted,
-                      fontSize: 13,
-                      fontWeight: 700,
-                      cursor: canSave ? 'pointer' : 'not-allowed',
-                      fontFamily: "'Noto Serif JP', serif",
-                      transition: 'opacity 0.2s ease',
-                      outlineOffset: 2,
-                    }}
-                  >
-                    {saving ? '保存中…' : '💾 回答を保存'}
-                  </button>
-                  {saveError && (
-                    <div role="alert" style={{
-                      marginTop: 8,
-                      fontSize: 12,
-                      color: P.score_lo,
-                      textAlign: 'center',
-                      fontFamily: "'Noto Serif JP', serif",
-                    }}>
-                      {saveError}
-                    </div>
-                  )}
-                  {savedTime && (
-                    <div style={{
-                      marginTop: 8,
-                      fontSize: 11,
-                      color: P.muted,
-                      textAlign: 'center',
-                      fontFamily: "'Outfit', sans-serif",
-                    }}>
-                      最終保存: {savedTime}
-                    </div>
-                  )}
-                </>
+              <button
+                type="button"
+                onClick={handleSaveDrafts}
+                disabled={!canSave}
+                style={{
+                  width: '100%',
+                  marginTop: 2,
+                  padding: '12px 16px',
+                  border: 'none',
+                  borderRadius: 8,
+                  background: canSave
+                    ? `linear-gradient(135deg, ${P.gold} 0%, ${P.goldDim} 100%)`
+                    : P.border,
+                  color: canSave ? '#fff' : P.muted,
+                  fontSize: 13,
+                  fontWeight: 700,
+                  cursor: canSave ? 'pointer' : 'not-allowed',
+                  fontFamily: "'Noto Serif JP', serif",
+                  transition: 'opacity 0.2s ease',
+                  outlineOffset: 2,
+                }}
+              >
+                {saving ? '保存中…' : '💾 回答を保存'}
+              </button>
+              {saveError && (
+                <div role="alert" style={{
+                  marginTop: 8,
+                  fontSize: 12,
+                  color: P.score_lo,
+                  textAlign: 'center',
+                  fontFamily: "'Noto Serif JP', serif",
+                }}>
+                  {saveError}
+                </div>
+              )}
+              {savedTime && (
+                <div style={{
+                  marginTop: 8,
+                  fontSize: 11,
+                  color: P.muted,
+                  textAlign: 'center',
+                  fontFamily: "'Outfit', sans-serif",
+                }}>
+                  最終保存: {savedTime}
+                </div>
               )}
             </div>
           )}

--- a/src/screens/uaam/SaikakuIntegration.jsx
+++ b/src/screens/uaam/SaikakuIntegration.jsx
@@ -391,8 +391,14 @@ export default function SaikakuIntegration({
 
     try {
       await onSave(items);
-      setDirtyByQuestion(new Map());
-      onDirtyChange?.(false);
+      const savedKeys = items
+        .map((item) => normalizeQuestionText(item.questionText))
+        .filter(Boolean);
+      setDirtyByQuestion((prev) => {
+        const next = new Map(prev);
+        for (const key of savedKeys) next.delete(key);
+        return next;
+      });
     } catch (e) {
       setSaveError(e?.message || '回答を保存できませんでした。再度お試しください。');
     }

--- a/src/screens/uaam/SaikakuIntegrationModal.jsx
+++ b/src/screens/uaam/SaikakuIntegrationModal.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import SaikakuIntegration, { formatIntegrationDate } from './SaikakuIntegration';
-import { loadCoachingAnswers } from '../../api/coachingAnswers';
+import { loadCoachingAnswers, saveCoachingAnswers } from '../../api/coachingAnswers';
 
 const LEGACY_MESSAGE = 'この統合分析は移行前のデータです。最新の組み合わせで再生成してください';
 
@@ -96,10 +96,17 @@ export default function SaikakuIntegrationModal({
   );
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [answersMap, setAnswersMap] = useState({});
+  const [saving, setSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState(null);
+  const [hasUnsavedAnswers, setHasUnsavedAnswers] = useState(false);
 
   useEffect(() => {
     if (open) setSelectedIndex(0);
   }, [open, integrationSummary, integrationSummaries]);
+
+  useEffect(() => {
+    if (open) setHasUnsavedAnswers(false);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -112,18 +119,39 @@ export default function SaikakuIntegrationModal({
     return () => { cancelled = true; };
   }, [open]);
 
+  const requestClose = useCallback(() => {
+    if (hasUnsavedAnswers && !window.confirm('保存していない回答があります。閉じますか？')) {
+      return;
+    }
+    onClose?.();
+  }, [hasUnsavedAnswers, onClose]);
+
   useEffect(() => {
     if (!open) return undefined;
 
     const handleKeyDown = (event) => {
-      if (event.key === 'Escape') onClose?.();
+      if (event.key === 'Escape') requestClose();
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [open, onClose]);
+  }, [open, requestClose]);
 
   if (!open) return null;
+
+  const handleCoachingSave = async (items) => {
+    setSaving(true);
+    try {
+      const updated = await saveCoachingAnswers(items);
+      setAnswersMap(updated);
+      setLastSavedAt(new Date());
+    } catch (e) {
+      console.warn('[coaching] save failed:', e);
+      throw e;
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const selectedSummary = summaries[selectedIndex] ?? summaries[0] ?? integrationSummary ?? null;
   const selectedSource = sourceFromSummary(selectedSummary, source);
@@ -134,7 +162,7 @@ export default function SaikakuIntegrationModal({
   return (
     <div
       data-testid="saikaku-integration-modal-backdrop"
-      onClick={onClose}
+      onClick={requestClose}
       style={{
         position: 'fixed',
         inset: 0,
@@ -214,7 +242,7 @@ export default function SaikakuIntegrationModal({
           <button
             type="button"
             aria-label="閉じる"
-            onClick={onClose}
+            onClick={requestClose}
             style={{
               width: 32,
               height: 32,
@@ -301,6 +329,10 @@ export default function SaikakuIntegrationModal({
                 source={selectedSource}
                 status={selectedSummary?.status}
                 answersMap={answersMap}
+                onSave={handleCoachingSave}
+                saving={saving}
+                lastSavedAt={lastSavedAt}
+                onDirtyChange={setHasUnsavedAnswers}
                 defaultOpen
                 readOnly
               />

--- a/src/screens/uaam/__tests__/SaikakuIntegrationModal.test.jsx
+++ b/src/screens/uaam/__tests__/SaikakuIntegrationModal.test.jsx
@@ -1,9 +1,19 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SaikakuIntegrationModal from '../SaikakuIntegrationModal';
 import SaikakuIntegration from '../SaikakuIntegration';
+
+const coachingMocks = vi.hoisted(() => ({
+  loadCoachingAnswers: vi.fn(),
+  saveCoachingAnswers: vi.fn(),
+}));
+
+vi.mock('../../../api/coachingAnswers', () => ({
+  loadCoachingAnswers: coachingMocks.loadCoachingAnswers,
+  saveCoachingAnswers: coachingMocks.saveCoachingAnswers,
+}));
 
 function integration(core) {
   return {
@@ -36,7 +46,13 @@ function summary(overrides = {}) {
 describe('SaikakuIntegrationModal', () => {
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    coachingMocks.loadCoachingAnswers.mockResolvedValue({});
+    coachingMocks.saveCoachingAnswers.mockResolvedValue({});
   });
 
   it('renders source header when given source prop', () => {
@@ -73,6 +89,42 @@ describe('SaikakuIntegrationModal', () => {
 
     await user.click(screen.getByTestId('saikaku-integration-modal-backdrop'));
 
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirms before closing when coaching answers are unsaved', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(
+      <SaikakuIntegrationModal
+        open
+        onClose={onClose}
+        kind="uaam"
+        integrationSummary={summary({
+          integration: {
+            ...integration('First Core'),
+            coaching_questions: ['この問いへの回答を書いてください'],
+          },
+        })}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText('あなたの考えを書いてみてください'), '未保存の回答');
+    await user.click(screen.getByTestId('saikaku-integration-modal-backdrop'));
+
+    expect(confirmSpy).toHaveBeenCalledWith('保存していない回答があります。閉じますか？');
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    expect(onClose).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValue(true);
+    await user.click(screen.getByRole('button', { name: '閉じる' }));
+
+    expect(confirmSpy).toHaveBeenCalledTimes(3);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/e2e/coaching-answers.spec.js
+++ b/tests/e2e/coaching-answers.spec.js
@@ -1,9 +1,13 @@
 import { test, expect } from '@playwright/test';
-import { Timestamp } from 'firebase-admin/firestore';
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { buildPairKey } from '../../shared/integrationsKey.js';
 import {
   clearUser,
   createAuthUser,
   loginAs,
+  saikakuAttempt,
+  saikakuParent,
   seedUser,
   uaamAttempt,
   uaamParent,
@@ -44,6 +48,37 @@ function parentWithIntegration() {
     hasSaikakuIntegration: true,
     integrationUpdatedAt: Timestamp.now(),
   };
+}
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+  }
+  return getFirestore();
+}
+
+async function seedIntegration(uid, saikakuAttemptId, uaamAttemptId, overrides = {}) {
+  const pairKey = buildPairKey(saikakuAttemptId, uaamAttemptId);
+  const now = Timestamp.now();
+  await getDb()
+    .collection('uaam_results')
+    .doc(uid)
+    .collection('integrations')
+    .doc(pairKey)
+    .set({
+      saikakuAttemptId,
+      uaamAttemptId,
+      integration: overrides.integration ?? SAIKAKU_INTEGRATION,
+      regenerationCount: overrides.regenerationCount ?? 0,
+      model: 'e2e-fixture',
+      source: overrides.source ?? {
+        saikakuLabel: 'E2E才覚',
+        uaamLabel: 'E2Eタイプ',
+      },
+      status: 'active',
+      createdAt: overrides.createdAt ?? now,
+      updatedAt: overrides.updatedAt ?? now,
+    });
 }
 
 test('coaching-answers: enter, save, reload restore', async ({ page }) => {
@@ -98,4 +133,57 @@ test('coaching-answers: enter, save, reload restore', async ({ page }) => {
   await expect(textareasAfterReload.nth(0)).toHaveValue('回答A');
   await expect(textareasAfterReload.nth(1)).toHaveValue('回答B');
   await expect(textareasAfterReload.nth(2)).toHaveValue('');
+});
+
+test('coaching-answers: history integration modal edit, save, reopen restore', async ({ page }) => {
+  const email = `e2e-coaching-modal-${Date.now()}@example.com`;
+  const password = 'password123';
+  const saikakuAttemptId = 'saikaku-attempt-1';
+  const uaamAttemptId = 'attempt-1';
+  const user = await createAuthUser(email, password);
+  await clearUser(user.uid);
+  await seedUser(user.uid, 'saikaku', {
+    parent: {
+      ...saikakuParent(1),
+      latestAttemptId: saikakuAttemptId,
+    },
+    attempts: { [saikakuAttemptId]: saikakuAttempt() },
+  });
+  await seedUser(user.uid, 'uaam', {
+    parent: uaamParent(1),
+    attempts: { [uaamAttemptId]: uaamAttempt() },
+  });
+  await seedIntegration(user.uid, saikakuAttemptId, uaamAttemptId);
+
+  await loginAs(page, email, password);
+
+  await expect(page.getByTestId('history-link-uaam')).toContainText('履歴を見る (1)', { timeout: 15000 });
+  await page.getByTestId('history-link-uaam').click();
+  await expect(page.getByTestId('history-item')).toHaveCount(1);
+
+  const banner = page.getByTestId('integration-banner');
+  await expect(banner).toBeVisible({ timeout: 10000 });
+  await banner.click();
+
+  const dialog = page.getByRole('dialog', { name: '才覚発動統合分析' });
+  await expect(dialog).toBeVisible({ timeout: 10000 });
+  await expect(dialog.getByText('コーチングキー質問')).toBeVisible({ timeout: 10000 });
+
+  const textareas = dialog.getByPlaceholder('あなたの考えを書いてみてください');
+  await expect(textareas).toHaveCount(3);
+  await textareas.nth(0).fill('履歴Modal回答A');
+  await textareas.nth(1).fill('履歴Modal回答B');
+
+  await dialog.getByRole('button', { name: /💾 回答を保存/ }).click();
+  await expect(dialog.getByText(/最終保存:/)).toBeVisible({ timeout: 10000 });
+
+  await dialog.getByRole('button', { name: '閉じる' }).click();
+  await expect(page.getByTestId('saikaku-integration-modal-backdrop')).toBeHidden();
+
+  await banner.click();
+  await expect(dialog).toBeVisible({ timeout: 10000 });
+  const textareasAfterReopen = dialog.getByPlaceholder('あなたの考えを書いてみてください');
+  await expect(textareasAfterReopen.nth(0)).toHaveValue('履歴Modal回答A');
+  await expect(textareasAfterReopen.nth(1)).toHaveValue('履歴Modal回答B');
+  await expect(textareasAfterReopen.nth(2)).toHaveValue('');
 });


### PR DESCRIPTION
## Summary

- Issue #69: `SaikakuIntegrationModal` (履歴の「統合分析あり」バッジから開くモーダル) からもコーチングキー質問の回答を編集・保存できるようにする
- PR #66 で導入した `readOnly=true` 時の textarea 非表示を、コーチング回答セクション分のみ revert
- Modal の Esc / 背景クリック / 閉じるボタンに未保存ガード (`window.confirm`) を追加

## 背景

PR #66 (commit 33100da) は `readOnly=true` 時に textarea を非表示にし、保存済み回答を read-only div で表示する変更だった。しかしユーザーの真意は逆方向で、「履歴経由でも編集できるようにしたい」だった。

## 変更内容

### 機能追加
- **`SaikakuIntegrationModal.jsx`**: `saveCoachingAnswers` import + `saving / lastSavedAt / hasUnsavedAnswers` state + `handleCoachingSave` + `requestClose` を内蔵。`<SaikakuIntegration>` に `onSave / saving / lastSavedAt / onDirtyChange` を渡す
- **`SaikakuIntegration.jsx`**: コーチング回答セクション内の `readOnly` ガードを撤去（textarea を常に表示）。`canSave` から `!readOnly` を除去。`onDirtyChange` prop で dirty 状態を親へ通知。保存成功時に dirty クリア
- **再生成ボタン (`!readOnly && ...`) は維持**: 履歴では再生成不要なので

### 未保存ガード (Codex review UX Critical 対応)
- `dirtyByQuestion.size > 0` のとき Esc / backdrop click / 閉じるボタンで `window.confirm('保存していない回答があります。閉じますか？')` を出す
- 保存成功後は `dirtyByQuestion` をクリアして dirty=false に戻す

### テスト追加
- 新規 E2E: `coaching-answers: history integration modal edit, save, reopen restore`
- 新規 unit test: 未保存時に `window.confirm` が呼ばれ cancel で閉じない / OK で閉じる

## Test plan

- [x] `npm run test:e2e -- coaching-answers` 全 pass
  - `coaching-answers: enter, save, reload restore` (4.0s) ✅
  - `coaching-answers: history integration modal edit, save, reopen restore` (3.2s) ✅
- [x] `npx vitest run src/screens/uaam/__tests__/SaikakuIntegrationModal.test.jsx src/screens/__tests__/HistoryScreen.integration-banner.test.jsx` 11 tests passed
- [x] PR #66 の readOnly ガードは「コーチングセクション内のみ」revert、再生成ボタン抑制セマンティクスは維持されていることを diff で確認
- [x] Codex 並列レビュー (8観点)
  - 初回 REJECT: UX Critical 1件 (未保存損失)
  - 修正後: Critical 解消、3観点 success / 5観点 timeout (再現性なし、コードレベルで対処済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)