### PR TITLE
feat(uaam): UAAMResultScreen に統合分析履歴インラインリストを追加 (#81)

### DIFF
--- a/api/me/uaam-result.js
+++ b/api/me/uaam-result.js
@@ -3,7 +3,7 @@ import { isLegacyFallback, listIntegrationDocs } from '../lib/legacyIntegration.
 import { responseStatusForIntegration } from '../lib/integrationStatus.js';
 import { serializeTimestamps } from '../lib/serialize.js';
 import { authenticateMeRequest, withMeHandler } from './_auth.js';
-import { isValidAttemptId, selectIntegrationForAttempt } from '../../shared/attemptLogic.js';
+import { isValidAttemptId, selectIntegrationForAttempt, timestampToMillis } from '../../shared/attemptLogic.js';
 
 function readSingleQueryValue(value) {
   return Array.isArray(value) ? value[0] : value;
@@ -60,8 +60,32 @@ function selectUaamIntegration(integrations, attemptId, attemptIsLegacy) {
   return null;
 }
 
-function emptyResult(includeIntegrationSummary) {
-  const response = { scores: null, analysis: null };
+function recentIntegrationSummary(integrationDoc, latestIds) {
+  const summary = integrationSummary(integrationDoc, latestIds);
+  if (!summary) return null;
+  if (integrationDoc?.isLegacyFallback === true) {
+    return { ...summary, isLegacyFallback: true };
+  }
+  return summary;
+}
+
+function compareRecentIntegrationSummaries(a, b) {
+  const aTime = timestampToMillis(a?.generatedAt) ?? Number.NEGATIVE_INFINITY;
+  const bTime = timestampToMillis(b?.generatedAt) ?? Number.NEGATIVE_INFINITY;
+  if (aTime !== bTime) return bTime - aTime;
+  return 0;
+}
+
+function recentIntegrationSummaries(integrations, latestIds) {
+  return integrations
+    .map((integrationDoc) => recentIntegrationSummary(integrationDoc, latestIds))
+    .filter(Boolean)
+    .sort(compareRecentIntegrationSummaries)
+    .slice(0, 2);
+}
+
+function emptyResult(includeIntegrationSummary, recent = []) {
+  const response = { scores: null, analysis: null, recentIntegrationSummaries: recent };
   if (includeIntegrationSummary) response.integrationSummary = null;
   return response;
 }
@@ -88,19 +112,21 @@ export default withMeHandler(async function handler(req, res) {
     parentRef.collection('integrations').get(),
   ]);
 
-  if (!snapshot.exists) {
-    return res.status(200).json(emptyResult(requestedAttemptId !== null));
-  }
-
-  const data = snapshot.data() || {};
+  const data = snapshot.exists ? (snapshot.data() || {}) : null;
   const integrations = listIntegrationDocs(integrationsSnap, data);
   const latestSaikakuAttemptId = saikakuParentSnap.exists
     ? saikakuParentSnap.data()?.latestAttemptId ?? null
     : null;
   const latestIds = {
     saikakuAttemptId: latestSaikakuAttemptId,
-    uaamAttemptId: data.latestAttemptId ?? null,
+    uaamAttemptId: data?.latestAttemptId ?? null,
   };
+  const recent = recentIntegrationSummaries(integrations, latestIds);
+
+  if (!snapshot.exists) {
+    return res.status(200).json(serializeTimestamps(emptyResult(requestedAttemptId !== null, recent)));
+  }
+
   const resolvedAttemptId = requestedAttemptId ?? data.latestAttemptId ?? null;
 
   let scores = data.scores ?? null;
@@ -128,7 +154,7 @@ export default withMeHandler(async function handler(req, res) {
   const includeIntegrationSummary = requestedAttemptId !== null || !!summary;
 
   if (!scores || !analysis) {
-    return res.status(200).json(emptyResult(includeIntegrationSummary));
+    return res.status(200).json(serializeTimestamps(emptyResult(includeIntegrationSummary, recent)));
   }
 
   const responseAnalysis = selectedIntegration?.integration
@@ -138,6 +164,7 @@ export default withMeHandler(async function handler(req, res) {
   const response = {
     scores,
     analysis: responseAnalysis,
+    recentIntegrationSummaries: recent,
   };
   if (includeIntegrationSummary) response.integrationSummary = summary;
 

--- a/api/me/uaam-result.js
+++ b/api/me/uaam-result.js
@@ -124,7 +124,10 @@ export default withMeHandler(async function handler(req, res) {
   const recent = recentIntegrationSummaries(integrations, latestIds);
 
   if (!snapshot.exists) {
-    return res.status(200).json(serializeTimestamps(emptyResult(requestedAttemptId !== null, recent)));
+    // 親 doc が存在しない場合、Firestore の仕様上 subcollection に orphaned
+    // integration が残っている可能性がある。ユーザー視点で「結果は無い」状態と
+    // 整合させるため、recentIntegrationSummaries は明示的に空配列で返す。
+    return res.status(200).json(serializeTimestamps(emptyResult(requestedAttemptId !== null, [])));
   }
 
   const resolvedAttemptId = requestedAttemptId ?? data.latestAttemptId ?? null;

--- a/docs/spec/integrations-schema.md
+++ b/docs/spec/integrations-schema.md
@@ -78,6 +78,26 @@ All fields are top-level fields. They are not nested under `analysis`.
   - For `kind='saikaku'`: returns ALL integrations whose `saikakuAttemptId === attemptId` as an array, same sort order.
 - Sort is deterministic — Firestore document order is NOT guaranteed.
 
+## Recent Integration Summaries (issue #81)
+
+- `/api/me/uaam-result` レスポンスに `recentIntegrationSummaries: SummaryShape[]` を**常に**含める。
+- 構築フロー（`api/me/uaam-result.js`）:
+  1. 既取得の `integrationsSnap` (= `listIntegrationDocs(integrationsSnap, data)`) を再利用し、追加の Firestore read は発生させない。
+  2. 各 doc に `integrationSummary(doc, latestIds)` を適用する。**body 欠損 doc は `null` を返す既存仕様を保持**。
+  3. `.filter(Boolean)` で null を除外。
+  4. `generatedAt` (= `updatedAt ?? createdAt`) で**降順 client-side sort** (`timestampToMillis` で正規化、null は `-Infinity` 扱い)。Firestore `orderBy` は使わない (PR #72 [P2] 踏襲)。
+  5. `.slice(0, 2)` で最大2件保証。
+  6. legacy fallback doc の場合は `isLegacyFallback: true` を含めて返す。
+- レスポンスの `serializeTimestamps` を必ず通すこと（Timestamp → ISO 8601 文字列）。
+- `recentIntegrationSummaries[].integration` に**統合分析本体を同梱**する（UI 側 modal で表示するため）。レスポンス payload 増加は 2件分 = 数KB で許容範囲。
+- 0件 (subcollection 空 / 全 body 欠損) のときは `[]` を返す。
+
+### UI consumer responsibility (`src/screens/uaam/UAAMResultScreen.jsx`)
+
+- `effectiveResult?.recentIntegrationSummaries ?? []` で読み取る（旧キャッシュ shape 防御）。
+- `analysis.saikaku_integration?.integration_score === undefined` の **else 分岐**（生成ボタン表示状態）でのみ描画。`isHistoryView` (= `attemptData` あり) では描画しない。
+- 行クリック / Enter / Space → `SaikakuIntegrationModal` を `kind="uaam"` + 単数 summary 渡しで起動。
+
 ## Migration Script
 
 - File: `scripts/migrate-integrations-to-subcollection.mjs`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,11 +4,11 @@
 
 | 層 | コマンド | カバレッジ | 所要時間 |
 |----|----------|------------|----------|
-| Unit | `npm run test:unit` | バッジ表示ロジック / attemptAdapter / AdminScreen 統合分析タブ (74 tests) | < 5 秒 |
+| Unit | `npm run test:unit` | バッジ表示ロジック / attemptAdapter / AdminScreen 統合分析タブ / UAAMResultScreen 最近の統合分析リスト (80 tests) | < 5 秒 |
 | Rules | `npm run test:rules` | Firestore rules 21 シナリオ (`/api/me/*` 経由化で attempts/uaam_results parent の read deny を反転検証) | 〜2 秒 |
-| API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency + `/api/me/*` BFF + `/api/admin/integrations` (122 tests) | 〜30 秒 |
-| E2E | `npm run test:e2e` | Playwright 29 フロー (badge/history/limit/admin-integrations 等) | 〜100 秒 |
-| **All** | `npm run test:all` | 全部直列実行 | 〜140 秒 |
+| API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency + `/api/me/*` BFF + `/api/admin/integrations` (126 tests) | 〜30 秒 |
+| E2E | `npm run test:e2e` | Playwright 39 フロー (badge/history/limit/admin-integrations/uaam-recent-integrations 等) | 〜170 秒 |
+| **All** | `npm run test:all` | 全部直列実行 | 〜210 秒 |
 
 ## 前提
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,20 +88,23 @@ function createSeedUaamResult() {
  * 保存済みUAAM結果を読み込む
  */
 async function loadSavedUaamResult(uid) {
-  void uid;
-  try {
-    if (!auth.currentUser) return null;
+  const currentUser = auth.currentUser;
+  if (!currentUser || currentUser.uid !== uid) return null;
 
-    const idToken = await auth.currentUser.getIdToken();
+  try {
+    const idToken = await currentUser.getIdToken();
+    if (auth.currentUser?.uid !== uid) return null;
+
     const res = await fetch('/api/me/uaam-result', {
       headers: { Authorization: `Bearer ${idToken}` },
     });
     if (!res.ok) return null;
 
     const data = await res.json();
+    if (auth.currentUser?.uid !== uid) return null;
     if (!data.scores || !data.analysis) return null;
 
-    return { scores: data.scores, analysis: data.analysis };
+    return data;
   } catch (e) {
     console.warn('[UAAM] Failed to load saved result:', e);
   }

--- a/src/screens/uaam/UAAMResultScreen.jsx
+++ b/src/screens/uaam/UAAMResultScreen.jsx
@@ -20,7 +20,8 @@ import {
 import ActivationMatrix from './ActivationMatrix';
 import AllPairsTriangle, { SymmetricMatrix } from './AllPairsTriangle';
 import ActivationPanel from '../../ActivationPanel';
-import SaikakuIntegration from './SaikakuIntegration';
+import SaikakuIntegration, { formatIntegrationDate } from './SaikakuIntegration';
+import SaikakuIntegrationModal from './SaikakuIntegrationModal';
 import { loadCoachingAnswers, saveCoachingAnswers } from '../../api/coachingAnswers';
 import { normalizeScores } from '../../utils/normalize';
 import { attemptToResultProps } from '../../utils/attemptAdapter';
@@ -140,6 +141,19 @@ function integrationSourceFromSummary(summary, analysis) {
       ?? summary.generatedAt
       ?? null,
   };
+}
+
+function recentIntegrationTitle(summary, index) {
+  return summary?.activationCore
+    ?? summary?.integration?.activation_core
+    ?? `統合分析 ${index + 1}`;
+}
+
+function recentIntegrationSourceLabel(summary) {
+  const source = summary?.source ?? {};
+  const saikakuLabel = source.saikakuLabel ?? summary?.saikakuAttemptId ?? '才覚領域';
+  const uaamLabel = source.uaamLabel ?? summary?.uaamAttemptId ?? 'UAAM';
+  return `${saikakuLabel} × ${uaamLabel}`;
 }
 
 function IntegrationNotice({ tone = 'stale', children, onRegenerate, disabled, loading }) {
@@ -1887,6 +1901,7 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
   // 統合分析は state で管理（バックフィル後に更新できるように）
   const [analysis, setAnalysis] = useState(() => effectiveResult?.analysis ?? null);
   const [integrationSummary, setIntegrationSummary] = useState(() => effectiveResult?.integrationSummary ?? null);
+  const [recentModalSummary, setRecentModalSummary] = useState(null);
   const [integrating, setIntegrating] = useState(false);
   const [integrateError, setIntegrateError] = useState('');
   const [coachingAnswersMap, setCoachingAnswersMap] = useState({});
@@ -2064,6 +2079,10 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
     const order = SUB_ORDER[axis.key];
     return { axis, data: order.map(k => subs[k] || 0), labels: order.map(k => SUB_LABELS[k]), order };
   });
+  const recentIntegrationSummaries = effectiveResult?.recentIntegrationSummaries ?? [];
+  const visibleRecentIntegrationSummaries = !isHistoryView && Array.isArray(recentIntegrationSummaries)
+    ? recentIntegrationSummaries.slice(0, 2)
+    : [];
   const integrationSource = integrationSourceFromSummary(integrationSummary, analysis);
   const integrationIsStale = integrationSummary?.status === 'stale';
   const integrationIsLegacy = isLegacyIntegrationSummary(integrationSummary);
@@ -2081,6 +2100,14 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
   const runLatestPairRegeneration = () => runIntegration({
     uaamAttemptId: integrationIsLegacy ? undefined : integrationSummary?.uaamAttemptId,
   });
+  const openRecentIntegration = (summary) => {
+    setRecentModalSummary(summary);
+  };
+  const handleRecentIntegrationKeyDown = (event, summary) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    openRecentIntegration(summary);
+  };
 
   return (
     <div style={{ minHeight: '100vh', background: LIGHT_BG }}>
@@ -2292,6 +2319,73 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
                     {integrateError}
                   </p>
                 )}
+                {visibleRecentIntegrationSummaries.length > 0 && (
+                  <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <div style={{
+                      fontSize: 11,
+                      fontWeight: 800,
+                      color: ACCENT_GOLD,
+                      letterSpacing: '0.08em',
+                    }}>
+                      過去の統合分析
+                    </div>
+                    {visibleRecentIntegrationSummaries.map((summary, index) => {
+                      const title = recentIntegrationTitle(summary, index);
+                      return (
+                        <div
+                          key={`${summary.saikakuAttemptId ?? 'saikaku'}-${summary.uaamAttemptId ?? 'uaam'}-${summary.generatedAt ?? index}`}
+                          data-testid={`recent-integration-${index}`}
+                          role="button"
+                          tabIndex={0}
+                          aria-label={`${title}を開く`}
+                          onClick={() => openRecentIntegration(summary)}
+                          onKeyDown={(event) => handleRecentIntegrationKeyDown(event, summary)}
+                          style={{
+                            border: `1px solid ${BORDER}`,
+                            background: LIGHT_BG,
+                            borderRadius: 8,
+                            padding: '11px 12px',
+                            cursor: 'pointer',
+                            textAlign: 'left',
+                          }}
+                        >
+                          <div style={{
+                            display: 'flex',
+                            alignItems: 'baseline',
+                            justifyContent: 'space-between',
+                            gap: 12,
+                            marginBottom: 4,
+                          }}>
+                            <span style={{
+                              color: TEXT_PRIMARY,
+                              fontSize: 13,
+                              fontWeight: 800,
+                              lineHeight: 1.5,
+                            }}>
+                              {title}
+                            </span>
+                            <span style={{
+                              color: TEXT_MUTED,
+                              fontSize: 11,
+                              fontWeight: 700,
+                              whiteSpace: 'nowrap',
+                            }}>
+                              {formatIntegrationDate(summary.generatedAt)}
+                            </span>
+                          </div>
+                          <div style={{
+                            color: TEXT_SECONDARY,
+                            fontSize: 11,
+                            lineHeight: 1.6,
+                            wordBreak: 'break-word',
+                          }}>
+                            {recentIntegrationSourceLabel(summary)}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </Section>
             )}
 
@@ -2333,6 +2427,12 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
           )}
         </div>
       </div>
+      <SaikakuIntegrationModal
+        open={!!recentModalSummary}
+        onClose={() => setRecentModalSummary(null)}
+        kind="uaam"
+        integrationSummary={recentModalSummary}
+      />
     </div>
   );
 }

--- a/tests/api/me-uaam-result.test.js
+++ b/tests/api/me-uaam-result.test.js
@@ -123,6 +123,26 @@ describe('API /api/me/uaam-result', () => {
     expect(response.body).toEqual({ scores: null, analysis: null, recentIntegrationSummaries: [] });
   });
 
+  it('returns empty recentIntegrationSummaries when parent is absent but orphaned subcollection docs exist', async () => {
+    // Firestore は親 doc 削除時に subcollection を残すため、orphaned integration が
+    // 残存しているケース。「結果は無い」状態と整合させるため空配列で返すこと。
+    const uid = 'u-me-uaam-result-absent-with-orphans';
+    await clearAllUserState(uid);
+    await seedIntegration(uid, 'saikaku-orphan-a', 'uaam-orphan-a', {
+      integration: integrationBody(91, 'Orphan Core A'),
+      updatedAt: at(2),
+    });
+    await seedIntegration(uid, 'saikaku-orphan-b', 'uaam-orphan-b', {
+      integration: integrationBody(82, 'Orphan Core B'),
+      updatedAt: at(1),
+    });
+
+    const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ scores: null, analysis: null, recentIntegrationSummaries: [] });
+  });
+
   it('returns null scores and analysis when saved result data is partial', async () => {
     const uid = 'u-me-uaam-result-partial';
     await clearUserState('uaam_results', uid);

--- a/tests/api/me-uaam-result.test.js
+++ b/tests/api/me-uaam-result.test.js
@@ -1,10 +1,99 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { db } from '../../api/lib/firebaseAdmin.js';
+import { buildPairKey } from '../../shared/integrationsKey.js';
 import {
+  Timestamp,
   api,
   clearUserState,
   seedParent,
 } from './_helpers.js';
+
+const SAIKAKU_CURRENT = 'saikaku-current';
+const UAAM_CURRENT = 'uaam-current';
+
+function at(day) {
+  return Timestamp.fromDate(new Date(`2026-05-0${day}T00:00:00.000Z`));
+}
+
+function scores() {
+  return {
+    mindset: { total: 60 },
+    literacy: { total: 62 },
+    competency: { total: 64 },
+    impact: { total: 66 },
+  };
+}
+
+function analysis() {
+  return {
+    type_name: '実装する案内人',
+    narrative: 'analysis',
+  };
+}
+
+function integrationBody(score, activationCore) {
+  return {
+    integration_score: score,
+    activation_core: activationCore,
+    activation_equation: `${activationCore} equation`,
+  };
+}
+
+async function clearIntegrationDocs(uid) {
+  const snap = await db.collection('uaam_results').doc(uid).collection('integrations').get();
+  if (snap.empty) return;
+
+  const batch = db.batch();
+  snap.docs.forEach((docSnap) => batch.delete(docSnap.ref));
+  await batch.commit();
+}
+
+async function clearAllUserState(uid) {
+  await clearIntegrationDocs(uid);
+  await Promise.all([
+    clearUserState('results', uid),
+    clearUserState('uaam_results', uid),
+  ]);
+}
+
+async function seedReadyUser(uid, overrides = {}) {
+  await clearAllUserState(uid);
+  await Promise.all([
+    seedParent('results', uid, {
+      latestAttemptId: overrides.latestSaikakuAttemptId ?? SAIKAKU_CURRENT,
+      selectedKakuchiiki: 'Saikaku Current',
+      result: { kakuchiiki: 'Saikaku Current' },
+      createdAt: at(1),
+    }),
+    seedParent('uaam_results', uid, {
+      latestAttemptId: overrides.latestUaamAttemptId ?? UAAM_CURRENT,
+      scores: overrides.scores ?? scores(),
+      analysis: overrides.analysis ?? analysis(),
+      createdAt: at(1),
+    }),
+  ]);
+}
+
+async function seedIntegration(uid, saikakuAttemptId, uaamAttemptId, overrides = {}) {
+  const pairKey = buildPairKey(saikakuAttemptId, uaamAttemptId);
+  const doc = {
+    saikakuAttemptId,
+    uaamAttemptId,
+    regenerationCount: overrides.regenerationCount ?? 0,
+    model: 'test-model',
+    source: {
+      saikakuLabel: `Saikaku ${saikakuAttemptId}`,
+      uaamLabel: `UAAM ${uaamAttemptId}`,
+    },
+    status: 'active',
+    createdAt: overrides.createdAt ?? at(1),
+    updatedAt: overrides.updatedAt ?? overrides.createdAt ?? at(1),
+  };
+  if (!overrides.omitIntegration) {
+    doc.integration = overrides.integration ?? integrationBody(88, 'Active Core');
+  }
+  await db.collection('uaam_results').doc(uid).collection('integrations').doc(pairKey).set(doc);
+}
 
 describe('API /api/me/uaam-result', () => {
   afterEach(() => {
@@ -21,7 +110,7 @@ describe('API /api/me/uaam-result', () => {
     const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
 
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({ scores, analysis });
+    expect(response.body).toEqual({ scores, analysis, recentIntegrationSummaries: [] });
   });
 
   it('returns null scores and analysis when parent is absent', async () => {
@@ -31,7 +120,7 @@ describe('API /api/me/uaam-result', () => {
     const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
 
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({ scores: null, analysis: null });
+    expect(response.body).toEqual({ scores: null, analysis: null, recentIntegrationSummaries: [] });
   });
 
   it('returns null scores and analysis when saved result data is partial', async () => {
@@ -42,7 +131,7 @@ describe('API /api/me/uaam-result', () => {
     const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
 
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({ scores: null, analysis: null });
+    expect(response.body).toEqual({ scores: null, analysis: null, recentIntegrationSummaries: [] });
   });
 
   it.each(['a/b', 'a.b', '..', '__reserved__'])(
@@ -73,6 +162,131 @@ describe('API /api/me/uaam-result', () => {
     expect(response.body).toEqual({
       code: 'internal_error',
       requestId: expect.any(String),
+    });
+  });
+
+  describe('recentIntegrationSummaries', () => {
+    it('returns the latest two summaries in generatedAt descending order with bodies and excludes body-missing docs', async () => {
+      const uid = 'u-me-uaam-result-recent-latest-two';
+      await seedReadyUser(uid);
+      await seedIntegration(uid, 'saikaku-old-a', 'uaam-old-a', {
+        integration: integrationBody(71, 'Old Core'),
+        updatedAt: at(1),
+      });
+      await seedIntegration(uid, 'saikaku-old-b', 'uaam-old-b', {
+        integration: integrationBody(93, 'Newest Core'),
+        regenerationCount: 1,
+        updatedAt: at(3),
+      });
+      await seedIntegration(uid, 'saikaku-old-c', 'uaam-old-c', {
+        integration: integrationBody(82, 'Middle Core'),
+        updatedAt: at(2),
+      });
+      await seedIntegration(uid, 'saikaku-old-d', 'uaam-old-d', {
+        omitIntegration: true,
+        updatedAt: at(4),
+      });
+
+      const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toHaveLength(2);
+      expect(response.body.recentIntegrationSummaries.map((item) => item.generatedAt)).toEqual([
+        '2026-05-03T00:00:00.000Z',
+        '2026-05-02T00:00:00.000Z',
+      ]);
+      expect(response.body.recentIntegrationSummaries).toEqual([
+        expect.objectContaining({
+          exists: true,
+          integrationScore: 93,
+          activationCore: 'Newest Core',
+          saikakuAttemptId: 'saikaku-old-b',
+          uaamAttemptId: 'uaam-old-b',
+          status: 'stale',
+          regenerationCount: 1,
+          source: { saikakuLabel: 'Saikaku saikaku-old-b', uaamLabel: 'UAAM uaam-old-b' },
+          integration: integrationBody(93, 'Newest Core'),
+        }),
+        expect.objectContaining({
+          exists: true,
+          integrationScore: 82,
+          activationCore: 'Middle Core',
+          saikakuAttemptId: 'saikaku-old-c',
+          uaamAttemptId: 'uaam-old-c',
+          status: 'stale',
+          regenerationCount: 0,
+          source: { saikakuLabel: 'Saikaku saikaku-old-c', uaamLabel: 'UAAM uaam-old-c' },
+          integration: integrationBody(82, 'Middle Core'),
+        }),
+      ]);
+      expect(response.body.recentIntegrationSummaries).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ uaamAttemptId: 'uaam-old-d' }),
+        ]),
+      );
+    });
+
+    it('returns [] when there are no integration docs', async () => {
+      const uid = 'u-me-uaam-result-recent-none';
+      await seedReadyUser(uid);
+
+      const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toEqual([]);
+    });
+
+    it('returns [] when all integration docs are missing bodies', async () => {
+      const uid = 'u-me-uaam-result-recent-all-body-missing';
+      await seedReadyUser(uid);
+      await seedIntegration(uid, 'saikaku-old-a', 'uaam-old-a', {
+        omitIntegration: true,
+        updatedAt: at(1),
+      });
+      await seedIntegration(uid, 'saikaku-old-b', 'uaam-old-b', {
+        omitIntegration: true,
+        updatedAt: at(2),
+      });
+
+      const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toEqual([]);
+    });
+
+    it('includes a legacy fallback summary with isLegacyFallback true', async () => {
+      const uid = 'u-me-uaam-result-recent-legacy';
+      await clearAllUserState(uid);
+      await seedParent('uaam_results', uid, {
+        scores: scores(),
+        analysis: {
+          ...analysis(),
+          saikaku_attempt_label: 'Legacy Saikaku',
+          uaam_attempt_label: 'Legacy UAAM',
+          saikaku_integration: integrationBody(77, 'Legacy Core'),
+        },
+        integrationUpdatedAt: at(3),
+        createdAt: at(1),
+      });
+
+      const response = await api.get('/api/me/uaam-result').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toEqual([
+        {
+          exists: true,
+          generatedAt: '2026-05-03T00:00:00.000Z',
+          integrationScore: 77,
+          activationCore: 'Legacy Core',
+          saikakuAttemptId: 'legacy-fallback',
+          uaamAttemptId: 'legacy-fallback',
+          status: 'active',
+          regenerationCount: 0,
+          source: { saikakuLabel: 'Legacy Saikaku', uaamLabel: 'Legacy UAAM' },
+          integration: integrationBody(77, 'Legacy Core'),
+          isLegacyFallback: true,
+        },
+      ]);
     });
   });
 });

--- a/tests/e2e/uaam-recent-integrations.spec.js
+++ b/tests/e2e/uaam-recent-integrations.spec.js
@@ -1,0 +1,218 @@
+import { test, expect } from '@playwright/test';
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { buildPairKey } from '../../shared/integrationsKey.js';
+import {
+  clearUser,
+  createAuthUser,
+  loginAs,
+  saikakuAttempt,
+  saikakuParent,
+  seedUser,
+  uaamAttempt,
+  uaamParent,
+  uaamResult,
+} from './_helpers.js';
+
+const password = 'password123';
+const createdUserIds = new Set();
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+  }
+  return getFirestore();
+}
+
+function at(day) {
+  return Timestamp.fromDate(new Date(`2026-05-0${day}T00:00:00.000Z`));
+}
+
+function uniqueEmail(slug, testInfo) {
+  const suffix = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2, 8)}`;
+  return `e2e-uaam-recent-${slug}-${suffix}@example.com`;
+}
+
+function integrationBody(score, activationCore) {
+  return {
+    integration_score: score,
+    activation_core: activationCore,
+    activation_equation: `${activationCore} equation`,
+  };
+}
+
+async function deleteCollectionDocs(collectionRef) {
+  const snap = await collectionRef.get();
+  if (snap.empty) return;
+
+  const batch = getDb().batch();
+  snap.docs.forEach((docSnap) => batch.delete(docSnap.ref));
+  await batch.commit();
+}
+
+async function clearIntegrationDocs(uid) {
+  await deleteCollectionDocs(getDb().collection('uaam_results').doc(uid).collection('integrations'));
+}
+
+async function clearAllUserData(uid) {
+  await clearIntegrationDocs(uid);
+  await clearUser(uid);
+}
+
+async function createCleanUser(slug, testInfo) {
+  const email = uniqueEmail(slug, testInfo);
+  const user = await createAuthUser(email, password);
+  createdUserIds.add(user.uid);
+  await clearAllUserData(user.uid);
+  return { email, user };
+}
+
+async function seedIntegration(uid, saikakuAttemptId, uaamAttemptId, overrides = {}) {
+  const pairKey = buildPairKey(saikakuAttemptId, uaamAttemptId);
+  await getDb().collection('uaam_results').doc(uid).collection('integrations').doc(pairKey).set({
+    saikakuAttemptId,
+    uaamAttemptId,
+    integration: overrides.integration ?? integrationBody(88, 'E2E Recent Core'),
+    regenerationCount: overrides.regenerationCount ?? 0,
+    model: 'e2e-fixture',
+    source: {
+      saikakuLabel: overrides.saikakuLabel ?? `E2E Saikaku ${saikakuAttemptId}`,
+      uaamLabel: overrides.uaamLabel ?? `E2E UAAM ${uaamAttemptId}`,
+    },
+    status: 'active',
+    createdAt: overrides.createdAt ?? at(1),
+    updatedAt: overrides.updatedAt ?? overrides.createdAt ?? at(1),
+  });
+}
+
+async function seedUserWithRecentIntegrations(uid) {
+  await Promise.all([
+    seedUser(uid, 'saikaku', {
+      parent: {
+        ...saikakuParent(1),
+        latestAttemptId: 'saikaku-current',
+      },
+      attempts: {
+        'saikaku-current': saikakuAttempt(),
+      },
+    }),
+    seedUser(uid, 'uaam', {
+      parent: {
+        ...uaamParent(1),
+        latestAttemptId: 'uaam-current',
+      },
+      attempts: {
+        'uaam-current': uaamAttempt(),
+      },
+    }),
+  ]);
+  await seedIntegration(uid, 'saikaku-old-a', 'uaam-old-a', {
+    integration: integrationBody(81, 'E2E Recent Core 1'),
+    createdAt: at(1),
+  });
+  await seedIntegration(uid, 'saikaku-old-b', 'uaam-old-b', {
+    integration: integrationBody(92, 'E2E Recent Core 2'),
+    createdAt: at(2),
+  });
+}
+
+async function waitForUaamResultResponse(page) {
+  return page.waitForResponse((response) => (
+    response.url().includes('/api/me/uaam-result')
+    && response.request().method() === 'GET'
+    && response.status() === 200
+  ), { timeout: 15000 });
+}
+
+async function openSavedUaamResult(page) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await page.evaluate(() => {
+      window.history.pushState({}, '', '/uaam/result');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    try {
+      await expect(page.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeVisible({ timeout: 1500 });
+      return;
+    } catch {
+      await page.waitForTimeout(250);
+    }
+  }
+
+  await expect(page.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeVisible({ timeout: 15000 });
+}
+
+async function loginAndOpenSavedResult(page, email) {
+  const resultResponse = waitForUaamResultResponse(page);
+  await loginAs(page, email, password);
+  await resultResponse;
+  await page.waitForLoadState('networkidle');
+  await openSavedUaamResult(page);
+}
+
+test.afterEach(async () => {
+  const userIds = [...createdUserIds];
+  createdUserIds.clear();
+  await Promise.all(userIds.map((uid) => clearAllUserData(uid)));
+});
+
+test('UAAM result shows two recent integration rows and opens modal by click and Enter', async ({ page }, testInfo) => {
+  const { email, user } = await createCleanUser('rows-modal', testInfo);
+  await seedUserWithRecentIntegrations(user.uid);
+
+  await loginAndOpenSavedResult(page, email);
+
+  await expect(page.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeVisible();
+  await expect(page.getByTestId('recent-integration-0')).toBeVisible();
+  await expect(page.getByTestId('recent-integration-1')).toBeVisible();
+  await expect(page.getByTestId('recent-integration-2')).toHaveCount(0);
+  await expect(page.getByTestId('recent-integration-0')).toContainText('E2E Recent Core 2');
+  await expect(page.getByTestId('recent-integration-1')).toContainText('E2E Recent Core 1');
+
+  await page.getByTestId('recent-integration-0').click();
+  const dialog = page.getByRole('dialog', { name: '才覚発動統合分析' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('E2E Recent Core 2', { exact: true })).toBeVisible();
+
+  await dialog.getByRole('button', { name: '閉じる' }).click();
+  await expect(dialog).toHaveCount(0);
+
+  await page.getByTestId('recent-integration-1').focus();
+  await page.keyboard.press('Enter');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('E2E Recent Core 1', { exact: true })).toBeVisible();
+});
+
+test('UAAM result old cache shape without recentIntegrationSummaries does not crash', async ({ page }, testInfo) => {
+  const { email } = await createCleanUser('old-cache', testInfo);
+  const cachedShape = uaamResult();
+  await page.route('**/api/me/uaam-result', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        scores: cachedShape.scores,
+        analysis: cachedShape.analysis,
+      }),
+    });
+  });
+
+  await loginAndOpenSavedResult(page, email);
+
+  await expect(page.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeVisible();
+  await expect(page.getByTestId('recent-integration-0')).toHaveCount(0);
+});
+
+test('UAAM history detail does not render recent integration rows', async ({ page }, testInfo) => {
+  const { email, user } = await createCleanUser('history-empty', testInfo);
+  await seedUserWithRecentIntegrations(user.uid);
+
+  await loginAs(page, email, password);
+  await expect(page.getByTestId('history-link-uaam')).toContainText('履歴を見る (1)', { timeout: 15000 });
+  await page.getByTestId('history-link-uaam').click();
+  await expect(page.getByTestId('history-item')).toHaveCount(1);
+  await page.getByTestId('history-item').first().click();
+
+  await expect(page.getByText('Unique Ability Activation Matrix').first()).toBeVisible();
+  await expect(page.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeVisible();
+  await expect(page.getByTestId('recent-integration-0')).toHaveCount(0);
+});

--- a/tests/unit/ui/uaam-result-recent-integrations.test.jsx
+++ b/tests/unit/ui/uaam-result-recent-integrations.test.jsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const coachingMocks = vi.hoisted(() => ({
+  loadCoachingAnswers: vi.fn(),
+  saveCoachingAnswers: vi.fn(),
+}));
+
+vi.mock('../../../src/firebase', () => ({
+  signOutUser: vi.fn(),
+}));
+
+vi.mock('../../../src/ActivationPanel', () => ({
+  default: () => <div data-testid="activation-panel" />,
+}));
+
+vi.mock('../../../src/screens/uaam/ActivationMatrix', () => ({
+  default: () => <div data-testid="activation-matrix" />,
+}));
+
+vi.mock('../../../src/screens/uaam/AllPairsTriangle', () => ({
+  default: () => <div data-testid="all-pairs-triangle" />,
+  SymmetricMatrix: () => <div data-testid="symmetric-matrix" />,
+}));
+
+vi.mock('../../../src/screens/uaam/SaikakuIntegration', () => ({
+  default: ({ integration }) => (
+    <div data-testid="modal-integration-body">
+      {integration?.activation_core ?? 'no integration'}
+    </div>
+  ),
+  formatIntegrationDate: (value) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '日付未設定';
+    return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+  },
+}));
+
+vi.mock('../../../src/api/coachingAnswers', () => ({
+  loadCoachingAnswers: coachingMocks.loadCoachingAnswers,
+  saveCoachingAnswers: coachingMocks.saveCoachingAnswers,
+}));
+
+import UAAMResultScreen from '../../../src/screens/uaam/UAAMResultScreen';
+
+const user = { uid: 'u-unit-uaam-recent', displayName: 'Unit User', photoURL: '' };
+const noop = () => {};
+
+function axisScore() {
+  return {
+    total: 60,
+    max: 80,
+    percentage: 75,
+    subs: {
+      meaning: 15,
+      mindfulness: 15,
+      mindshift: 15,
+      mastery: 15,
+      learning: 15,
+      logical: 15,
+      life: 15,
+      leadership: 15,
+      critical: 15,
+      creativity: 15,
+      communication: 15,
+      collaboration: 15,
+      idea: 15,
+      innovation: 15,
+      implementation: 15,
+      influence: 15,
+    },
+    domainSubs: {},
+    domainTotal: 60,
+  };
+}
+
+function baseResult(overrides = {}) {
+  return {
+    scores: {
+      mindset: axisScore(),
+      literacy: axisScore(),
+      competency: axisScore(),
+      impact: axisScore(),
+    },
+    analysis: {
+      type_name: 'Unit Type',
+      narrative: 'Unit narrative',
+      axis_analysis: {
+        mindset: 'mindset',
+        literacy: 'literacy',
+        competency: 'competency',
+        impact: 'impact',
+      },
+      strengths: ['strength'],
+      growth_areas: ['growth'],
+      action_suggestions: ['action'],
+    },
+    bias_message: null,
+    personality_level: { level: 'L4', name: '自律型', confidence: 'medium', signals: [] },
+    leadership_stage: { stage: 3, name: '自律' },
+    three_elements: {
+      leadership: 60,
+      teamBuilding: 55,
+      management: 50,
+      development_phase: 'phase-2',
+    },
+    answers: {},
+    vAnswers: {},
+    name: 'Unit User',
+    ...overrides,
+  };
+}
+
+function recentSummary(index, overrides = {}) {
+  const core = `Recent Core ${index + 1}`;
+  return {
+    exists: true,
+    generatedAt: `2026-05-0${index + 1}T00:00:00.000Z`,
+    integrationScore: 80 + index,
+    activationCore: core,
+    saikakuAttemptId: `saikaku-${index + 1}`,
+    uaamAttemptId: `uaam-${index + 1}`,
+    status: 'stale',
+    regenerationCount: 0,
+    source: {
+      saikakuLabel: `Saikaku ${index + 1}`,
+      uaamLabel: `UAAM ${index + 1}`,
+    },
+    integration: {
+      integration_score: 80 + index,
+      activation_core: core,
+      activation_equation: `${core} equation`,
+    },
+    ...overrides,
+  };
+}
+
+function renderScreen(result) {
+  return render(
+    <UAAMResultScreen
+      user={user}
+      result={result}
+      isAdmin={false}
+      onReset={noop}
+      onAdmin={noop}
+      onLogout={noop}
+    />,
+  );
+}
+
+describe('UAAMResultScreen recent integrations', () => {
+  beforeEach(() => {
+    coachingMocks.loadCoachingAnswers.mockResolvedValue({});
+    coachingMocks.saveCoachingAnswers.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    [0, []],
+    [1, [recentSummary(0)]],
+    [2, [recentSummary(0), recentSummary(1)]],
+  ])('renders %i recent integration rows', (count, recentIntegrationSummaries) => {
+    renderScreen(baseResult({ recentIntegrationSummaries }));
+
+    if (count >= 1) expect(screen.getByTestId('recent-integration-0')).toBeInTheDocument();
+    else expect(screen.queryByTestId('recent-integration-0')).toBeNull();
+    if (count >= 2) expect(screen.getByTestId('recent-integration-1')).toBeInTheDocument();
+    else expect(screen.queryByTestId('recent-integration-1')).toBeNull();
+    expect(screen.queryByTestId('recent-integration-2')).toBeNull();
+  });
+
+  it('does not crash when recentIntegrationSummaries is missing from an old cache shape', () => {
+    renderScreen(baseResult());
+
+    expect(screen.queryByTestId('recent-integration-0')).toBeNull();
+    expect(screen.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeInTheDocument();
+  });
+
+  it('opens the UAAM modal with the clicked single summary', async () => {
+    const userEventApi = userEvent.setup();
+    renderScreen(baseResult({
+      recentIntegrationSummaries: [recentSummary(0), recentSummary(1)],
+    }));
+
+    await userEventApi.click(screen.getByTestId('recent-integration-1'));
+
+    const dialog = await screen.findByRole('dialog', { name: '才覚発動統合分析' });
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Recent Core 2')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('opens the modal from Space key activation without crashing', async () => {
+    const userEventApi = userEvent.setup();
+    renderScreen(baseResult({
+      recentIntegrationSummaries: [recentSummary(0)],
+    }));
+
+    screen.getByTestId('recent-integration-0').focus();
+    await userEventApi.keyboard('[Space]');
+
+    expect(await screen.findByRole('dialog', { name: '才覚発動統合分析' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- UAAMResultScreen の「⚡ 才覚×UAAM 統合発動分析を生成する」ボタン表示状態（最新ペアの integration が未生成 / 旧形式）で、過去に生成した他組み合わせの統合分析を最大2件クリッカブル表示する
- 行クリック / Enter / Space で `SaikakuIntegrationModal` を `kind=\"uaam\"` + 単数 summary 渡しで起動
- 診断済みでも「やってない」と錯覚して再生成する誤操作を抑止する

Closes #81

## Scope

- API: `/api/me/uaam-result` レスポンスに `recentIntegrationSummaries: SummaryShape[]` (最大2件、`generatedAt` 降順、body 同梱、`.filter(Boolean)` で body 欠損 doc 除外) を追加
- UI: `UAAMResultScreen.jsx` の else 分岐 Section 末尾（`integrateError` の後）に行リストを描画。`data-testid`, `role=\"button\"`, `tabIndex={0}`, `aria-label`, Enter/Space ハンドリング完備
- App.jsx: `loadSavedUaamResult` を API response 全体を返すように変更。同時に uid race guard を3箇所追加（pre-call / post-token / post-fetch）
- Tests: Unit / API / E2E すべてに新規ケース追加（Codex code-review 8観点で精査済み）

## Design Notes

### 既存仕様の不変条件 (Codex review C1-C8 準拠)

- C1: `integrationSummary()` の戻り値仕様（body なし → `null`）は変更なし
- C2: `selectIntegrationForAttempt` / `selectUaamIntegration` 不変
- C3: Modal は単数 summary 渡し（複数 selector は出さない）
- C4: history view (`attemptData` 由来) では行を描画しない（`attemptAdapter` に新フィールドを足さない）
- C5: 行リスト挿入順序は SectionHeader → 説明 → 生成ボタン → integrateError → recent rows
- C6: data-testid / role / tabIndex / aria-label / Enter+Space (Space は preventDefault)
- C7: `effectiveResult?.recentIntegrationSummaries ?? []` で旧 cache shape 防御
- C8: body 欠損 doc 除外は API 側 `.filter(Boolean)` で実施（UI 側は filter しない）

### Firestore read 最適化

既取得の `integrationsSnap` (`listIntegrationDocs` 結果) を再利用するため、追加の Firestore read は発生しない。

### body 同梱の理由

else 分岐では最新 integration が SaikakuIntegration コンポーネントとして描画されていない。recent 行クリック時に詳細を Modal で表示するために body が必要。payload 増加は 2件分 = 数KB で許容範囲。

### Recent summaries の sort

`integrationSummary()` 適用後の `generatedAt` 降順のみ。`updatedAt ?? createdAt ?? null` のフォールバックは既存ヘルパー内で解決済み。Firestore `orderBy` は使わず client-side で sort（PR #72 [P2] 踏襲）。

### `loadSavedUaamResult` の uid race guard

`return data` への shape 拡張で `recentIntegrationSummaries` が `uaamResult` state に流入するようになったため、既存の race condition（uid 無視）の影響範囲が広がった。これに対応する最小修正として、3箇所に `auth.currentUser?.uid === uid` チェックを追加。

## Test plan

- [x] `npm run test:unit` — 10 files / 80 tests passed
- [x] `npm run test:api` — 22 files / 126 tests passed
- [x] `npm run test:e2e` — 39 passed (2.8m)
- [x] Codex code-review 8観点（security / performance / error-handling / code-quality / maintainability / accessibility / ux / best-practices）実行済み。issue #81 由来の Critical 指摘（`loadSavedUaamResult` race guard）は本 PR で対応済み。他の High/Medium 指摘はすべて既存コードへの指摘で別 issue 化推奨
- [ ] UI 手動確認（後続レビュアー）:
  - (a) 最新ペア未生成 & 過去 integration 2件 seed → 「生成する」ボタン + その下に行2件表示
  - (b) 行クリック / Enter / Space で Modal 開く
  - (c) `integrateError` 状態で ボタン → エラー → リスト の順
  - (d) 旧 cache 状態でリロード → crash なし
  - (e) history view では行が描画されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)