### PR TITLE
feat(admin): UAAM 診断結果の CSV エクスポート (#87)

### DIFF
--- a/api/admin/users.js
+++ b/api/admin/users.js
@@ -60,7 +60,10 @@ export default async function handler(req, res) {
       photoURL: d.photoURL || '',
       scores: d.scores || null,
       analysis: d.analysis || null,
-      bias_message: d.bias_message || null,
+      // bias_message は undefined / null / object の三状態を区別する（AdminScreen.getOrCalcBias 参照）。
+      // undefined = legacy（再計算）、null = 明示的に健全保存、object = 保存済みメッセージ。
+      // `|| null` の coercion は legacy を健全と誤認させるため使わない。
+      bias_message: d.bias_message,
       answers: d.answers || null,
       vAnswers: d.vAnswers || null,
       uaamCreatedAt: d.createdAt?._seconds

--- a/api/admin/users.js
+++ b/api/admin/users.js
@@ -60,6 +60,7 @@ export default async function handler(req, res) {
       photoURL: d.photoURL || '',
       scores: d.scores || null,
       analysis: d.analysis || null,
+      bias_message: d.bias_message || null,
       answers: d.answers || null,
       vAnswers: d.vAnswers || null,
       uaamCreatedAt: d.createdAt?._seconds

--- a/src/screens/AdminScreen.jsx
+++ b/src/screens/AdminScreen.jsx
@@ -4,6 +4,8 @@ import { Chart, computePcts, CHART_COLORS } from '../utils/chartUtils';
 import ActivationPanel from '../ActivationPanel';
 import ActivationMatrix from './uaam/ActivationMatrix';
 import SaikakuIntegrationModal from './uaam/SaikakuIntegrationModal';
+import { buildCsv, downloadCsv } from '../utils/exportCsv';
+import { buildUaamRows, UAAM_EXPORT_FIELD_DEFS } from '../utils/uaamExport';
 import {
   getVFlags,
   calculateBiasMessage,
@@ -1176,6 +1178,23 @@ export default function AdminScreen({ user, onBack, onLogout }) {
     }
   };
 
+  const handleExportUaam = () => {
+    setExporting(true);
+    try {
+      if (uaamUsers.length === 0) {
+        alert('UAAMデータがありません');
+        return;
+      }
+
+      const csvText = buildCsv(buildUaamRows(uaamUsers), UAAM_EXPORT_FIELD_DEFS);
+      downloadCsv('uaam_results.csv', csvText);
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      setExporting(false);
+    }
+  };
+
   // 本日・今週のカウントと検索フィルター（usersやsearchが変わった時のみ再計算）
   const today = useMemo(() => {
     const todayStr = new Date().toDateString();
@@ -1783,6 +1802,23 @@ export default function AdminScreen({ user, onBack, onLogout }) {
               <option value="v2_flag">V2フラグあり</option>
               <option value="v3_flag">V3フラグあり</option>
             </select>
+            <button
+              onClick={handleExportUaam}
+              disabled={exporting}
+              style={{
+                padding: '8px 20px',
+                borderRadius: 8,
+                border: 'none',
+                background: '#C4922A',
+                color: '#FDFCFA',
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: exporting ? 'wait' : 'pointer',
+                opacity: exporting ? 0.7 : 1,
+              }}
+            >
+              {exporting ? '処理中...' : 'CSVエクスポート'}
+            </button>
           </div>
         </div>
 

--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -1,12 +1,17 @@
 const UTF8_BOM = '\uFEFF';
+const FORMULA_PREFIX_RE = /^[=+\-@\t\r]/;
 
 function normalizeCellValue(value) {
   if (value === null || value === undefined) return '';
   return String(value);
 }
 
+function neutralizeFormula(text) {
+  return FORMULA_PREFIX_RE.test(text) ? `'${text}` : text;
+}
+
 function escapeCsvCell(value) {
-  const text = normalizeCellValue(value);
+  const text = neutralizeFormula(normalizeCellValue(value));
   const escaped = text.replace(/"/g, '""');
   return /[,"\n\r]/.test(escaped) ? `"${escaped}"` : escaped;
 }

--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -1,0 +1,48 @@
+const UTF8_BOM = '\uFEFF';
+
+function normalizeCellValue(value) {
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+function escapeCsvCell(value) {
+  const text = normalizeCellValue(value);
+  const escaped = text.replace(/"/g, '""');
+  return /[,"\n\r]/.test(escaped) ? `"${escaped}"` : escaped;
+}
+
+export function buildCsv(rows, fieldDefs) {
+  if (!Array.isArray(rows)) throw new TypeError('rows must be an array');
+  if (!Array.isArray(fieldDefs)) throw new TypeError('fieldDefs must be an array');
+
+  const header = fieldDefs.map((field) => escapeCsvCell(field.label)).join(',');
+  const body = rows.map((row) => (
+    fieldDefs.map((field) => {
+      const rawValue = row?.[field.key];
+      const value = field.format ? field.format(rawValue) : rawValue;
+      return escapeCsvCell(value);
+    }).join(',')
+  ));
+
+  return `${UTF8_BOM}${[header].concat(body).join('\r\n')}`;
+}
+
+export function downloadCsv(filename, csvText) {
+  const blob = new Blob([csvText], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  let link = null;
+
+  try {
+    link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+  } finally {
+    if (link?.parentNode) {
+      link.parentNode.removeChild(link);
+    }
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/utils/uaamExport.js
+++ b/src/utils/uaamExport.js
@@ -1,0 +1,59 @@
+import { getVFlags } from '../data/uaam_questions';
+
+export const UAAM_EXPORT_FIELD_DEFS = [
+  { key: 'name', label: '名前' },
+  { key: 'email', label: 'メール' },
+  { key: 'mindset', label: '志(%)' },
+  { key: 'literacy', label: '知(%)' },
+  { key: 'competency', label: '技(%)' },
+  { key: 'impact', label: '衝(%)' },
+  { key: 'v1', label: 'V1' },
+  { key: 'v2', label: 'V2' },
+  { key: 'v3', label: 'V3' },
+  { key: 'bias_level', label: 'bias_level' },
+  { key: 'bias_message', label: 'bias_message' },
+  { key: 'type_name', label: 'タイプ名' },
+  { key: 'uaamUpdatedAt', label: '診断日' },
+];
+
+export function pct(score) {
+  if (score == null) return '';
+  return score.percentage ?? Math.round((score.total / (score.max || 1)) * 100);
+}
+
+export function formatJpDate(value) {
+  if (!value) return '';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+
+  return date.toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).replace(/\//g, '-');
+}
+
+export function buildUaamRows(uaamUsers) {
+  if (!Array.isArray(uaamUsers)) throw new TypeError('uaamUsers must be an array');
+
+  return uaamUsers.map((u) => {
+    const vFlags = getVFlags(u.vAnswers ?? {});
+
+    return {
+      name: u.name ?? '',
+      email: u.email ?? '',
+      mindset: pct(u.scores?.mindset),
+      literacy: pct(u.scores?.literacy),
+      competency: pct(u.scores?.competency),
+      impact: pct(u.scores?.impact),
+      v1: vFlags.flags.V1 ?? 'none',
+      v2: vFlags.flags.V2 ?? 'none',
+      v3: vFlags.flags.V3 ?? 'none',
+      bias_level: vFlags.level,
+      bias_message: u.bias_message?.message ?? '',
+      type_name: u.analysis?.type_name ?? '',
+      uaamUpdatedAt: formatJpDate(u.uaamUpdatedAt),
+    };
+  });
+}

--- a/src/utils/uaamExport.js
+++ b/src/utils/uaamExport.js
@@ -1,4 +1,4 @@
-import { getVFlags } from '../data/uaam_questions';
+import { getVFlags, calculateBiasMessage } from '../data/uaam_questions';
 
 export const UAAM_EXPORT_FIELD_DEFS = [
   { key: 'name', label: '名前' },
@@ -19,6 +19,20 @@ export const UAAM_EXPORT_FIELD_DEFS = [
 export function pct(score) {
   if (score == null) return '';
   return score.percentage ?? Math.round((score.total / (score.max || 1)) * 100);
+}
+
+// AdminScreen.getOrCalcBias と同じ三状態 (undefined=legacy→recalc, null=明示的健全, object=保存済み) を保持する。
+// CSV と UI の bias 表示を完全一致させるため、UI 側ロジックを inline 複製。
+export function resolveBiasMessage(u) {
+  if (u.bias_message !== undefined && u.bias_message !== null) return u.bias_message;
+  if (u.bias_message === null) return null;
+  const v = u.vAnswers || {};
+  const s = u.scores || {};
+  const totalPct = Math.round(
+    ((s.mindset?.total || 0) + (s.literacy?.total || 0) +
+      (s.competency?.total || 0) + (s.impact?.total || 0)) / 320 * 100,
+  );
+  return calculateBiasMessage(v, totalPct);
 }
 
 export function formatJpDate(value) {
@@ -51,7 +65,7 @@ export function buildUaamRows(uaamUsers) {
       v2: vFlags.flags.V2 ?? 'none',
       v3: vFlags.flags.V3 ?? 'none',
       bias_level: vFlags.level,
-      bias_message: u.bias_message?.message ?? '',
+      bias_message: resolveBiasMessage(u)?.message ?? '',
       type_name: u.analysis?.type_name ?? '',
       uaamUpdatedAt: formatJpDate(u.uaamUpdatedAt),
     };

--- a/tests/e2e/_helpers.js
+++ b/tests/e2e/_helpers.js
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { initializeApp, getApps } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import { getFirestore, Timestamp } from 'firebase-admin/firestore';
@@ -86,6 +89,29 @@ export async function loginAs(page, email, password) {
   await page.getByPlaceholder('パスワード（6文字以上）').fill(password);
   await page.locator('.login-btn-gold').click();
   await expect(page.getByText('才覚解読プログラム')).toBeVisible({ timeout: 15000 });
+}
+
+export async function downloadCsvAndAssert(page, clickAction, expectedFilename) {
+  const downloadPromise = page.waitForEvent('download', { timeout: 15000 });
+  const clickPromise = typeof clickAction === 'function'
+    ? clickAction()
+    : clickAction.click();
+
+  const [download] = await Promise.all([
+    downloadPromise,
+    clickPromise,
+  ]);
+
+  expect(download.suggestedFilename()).toBe(expectedFilename);
+
+  const dir = await mkdtemp(join(tmpdir(), 'saikaku-e2e-csv-'));
+  const filePath = join(dir, expectedFilename);
+  await download.saveAs(filePath);
+  const csvText = await readFile(filePath, 'utf8');
+
+  expect(csvText.startsWith('\uFEFF')).toBe(true);
+
+  return { download, csvText };
 }
 
 export async function fillSaikakuForm(page) {

--- a/tests/e2e/admin-uaam-export.spec.js
+++ b/tests/e2e/admin-uaam-export.spec.js
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test';
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+  clearUser,
+  createAuthUser,
+  downloadCsvAndAssert,
+  loginAs,
+  seedUser,
+  uaamParent,
+} from './_helpers.js';
+
+const password = 'password123';
+const adminEmail = (process.env.ADMIN_EMAILS || process.env.VITE_ADMIN_EMAILS || 'admin-e2e@example.com')
+  .split(',')
+  .map((email) => email.trim())
+  .filter(Boolean)[0];
+
+const UAAM_UID = 'e2e-admin-uaam-export-1';
+const UAAM_EMAIL = 'e2e-admin-uaam-export-1@example.com';
+const UAAM_NAME = 'E2E UAAM Export User';
+const UAAM_TYPE_NAME = 'E2E Export Type';
+const BIAS_MESSAGE = 'E2E bias message';
+const COACHING_ANSWER_SECRET = 'e2e_export_secret_coaching_answer';
+const UPDATED_AT = Timestamp.fromDate(new Date('2026-05-07T12:00:00.000Z'));
+const EXPECTED_HEADER = '名前,メール,志(%),知(%),技(%),衝(%),V1,V2,V3,bias_level,bias_message,タイプ名,診断日';
+
+function getAdminAuth() {
+  if (!getApps().length) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+  }
+  return getAuth();
+}
+
+async function deleteAuthUserByEmail(email) {
+  try {
+    const user = await getAdminAuth().getUserByEmail(email);
+    await clearUser(user.uid);
+    await getAdminAuth().deleteUser(user.uid);
+  } catch (e) {
+    if (e.code !== 'auth/user-not-found') throw e;
+  }
+}
+
+async function cleanup() {
+  await clearUser(UAAM_UID);
+  await deleteAuthUserByEmail(adminEmail);
+}
+
+function axisScore(total, max, percentage) {
+  return {
+    total,
+    max,
+    percentage,
+    subs: {},
+    domainSubs: {},
+    domainTotal: total,
+  };
+}
+
+async function seedUaamExportFixture() {
+  await seedUser(UAAM_UID, 'uaam', {
+    parent: {
+      ...uaamParent(1),
+      uid: UAAM_UID,
+      name: UAAM_NAME,
+      email: UAAM_EMAIL,
+      scores: {
+        mindset: axisScore(70, 80, 88),
+        literacy: axisScore(40, 60, 67),
+        competency: axisScore(30, 50, 60),
+        impact: axisScore(21, 50, 42),
+      },
+      vAnswers: {
+        V1: 1,
+        V2: 2,
+        V3: 3,
+      },
+      analysis: {
+        type_name: UAAM_TYPE_NAME,
+      },
+      bias_message: {
+        message: BIAS_MESSAGE,
+      },
+      coaching_answers: {
+        exportLeakGuard: {
+          answer: COACHING_ANSWER_SECRET,
+        },
+      },
+      createdAt: UPDATED_AT,
+      updatedAt: UPDATED_AT,
+    },
+  });
+}
+
+test.beforeEach(async () => {
+  await cleanup();
+});
+
+test.afterEach(async () => {
+  await cleanup();
+});
+
+test('admin can export UAAM results as CSV', async ({ page }) => {
+  const admin = await createAuthUser(adminEmail, password);
+  await clearUser(admin.uid);
+  await seedUaamExportFixture();
+
+  await loginAs(page, adminEmail, password);
+  await page.goto('/admin');
+
+  await expect(page.getByRole('button', { name: /UAAM診断/ })).toBeVisible({ timeout: 15000 });
+  await page.getByRole('button', { name: /UAAM診断/ }).click();
+  await expect(page.getByText(UAAM_EMAIL)).toBeVisible({ timeout: 15000 });
+
+  const exportButton = page.getByRole('button', { name: 'CSVエクスポート' });
+  await expect(exportButton).toBeVisible();
+
+  const { csvText } = await downloadCsvAndAssert(page, exportButton, 'uaam_results.csv');
+  const lines = csvText.split('\r\n');
+  const bodyRow = lines.find((line) => line.includes(UAAM_EMAIL));
+
+  expect(lines[0]).toContain(EXPECTED_HEADER);
+  expect(bodyRow).toBeTruthy();
+  expect(bodyRow).not.toContain(COACHING_ANSWER_SECRET);
+  expect(csvText).not.toContain(COACHING_ANSWER_SECRET);
+  expect(csvText).not.toContain('coaching_answers');
+  expect(bodyRow.split(',')).toEqual([
+    UAAM_NAME,
+    UAAM_EMAIL,
+    '88',
+    '67',
+    '60',
+    '42',
+    'critical',
+    'warning',
+    'none',
+    '4',
+    BIAS_MESSAGE,
+    UAAM_TYPE_NAME,
+    '2026-05-07',
+  ]);
+});

--- a/tests/utils/__snapshots__/exportCsv.test.js.snap
+++ b/tests/utils/__snapshots__/exportCsv.test.js.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildCsv > matches the UAAM export column order snapshot 1`] = `
+"﻿名前,メール,志(%),知(%),技(%),衝(%),V1,V2,V3,bias_level,bias_message,タイプ名,診断日
+Alice,alice@example.com,0,80,75,90,none,warning,critical,5,needs review,天地型,2026-05-01
+Bob,bob@example.com,,,,,none,none,none,1,,未分類,"
+`;

--- a/tests/utils/exportCsv.test.js
+++ b/tests/utils/exportCsv.test.js
@@ -35,6 +35,25 @@ describe('buildCsv', () => {
     expect(csv).toBe('\uFEFFA,B\r\n,');
   });
 
+  it('neutralizes formula-leading cells to prevent CSV injection', () => {
+    const csv = buildCsv(
+      [
+        { name: '=cmd|"/c calc"!A1', email: '+SUM(A1)' },
+        { name: '-2+3+cmd', email: '@SUM(A1)' },
+        { name: '\tinjected', email: 'safe@example.com' },
+      ],
+      [
+        { key: 'name', label: 'Name' },
+        { key: 'email', label: 'Email' },
+      ],
+    );
+
+    const lines = csv.split('\r\n');
+    expect(lines[1]).toBe('"\'=cmd|""/c calc""!A1",\'+SUM(A1)');
+    expect(lines[2]).toBe("'-2+3+cmd,'@SUM(A1)");
+    expect(lines[3]).toBe("'\tinjected,safe@example.com");
+  });
+
   it('only exports allowlisted fields', () => {
     const csv = buildCsv([{ a: 1, secret: 'leaked' }], [
       { key: 'a', label: 'A' },

--- a/tests/utils/exportCsv.test.js
+++ b/tests/utils/exportCsv.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { buildCsv } from '../../src/utils/exportCsv.js';
+import { UAAM_EXPORT_FIELD_DEFS } from '../../src/utils/uaamExport.js';
+
+describe('buildCsv', () => {
+  it('writes the header row from field labels', () => {
+    const csv = buildCsv([{ name: 'Alice', email: 'alice@example.com' }], [
+      { key: 'name', label: '名前' },
+      { key: 'email', label: 'メール' },
+    ]);
+
+    expect(csv.split('\r\n')[0]).toBe('\uFEFF名前,メール');
+  });
+
+  it('wraps comma, quote, and newline values and escapes inner quotes', () => {
+    const csv = buildCsv([{ note: 'a,b"c\nd' }], [
+      { key: 'note', label: 'Note' },
+    ]);
+
+    expect(csv).toBe('\uFEFFNote\r\n"a,b""c\nd"');
+  });
+
+  it('starts with a UTF-8 BOM', () => {
+    const csv = buildCsv([], [{ key: 'a', label: 'A' }]);
+
+    expect(csv.startsWith('\uFEFF')).toBe(true);
+  });
+
+  it('renders null and undefined values as empty strings', () => {
+    const csv = buildCsv([{ a: null, b: undefined }], [
+      { key: 'a', label: 'A' },
+      { key: 'b', label: 'B' },
+    ]);
+
+    expect(csv).toBe('\uFEFFA,B\r\n,');
+  });
+
+  it('only exports allowlisted fields', () => {
+    const csv = buildCsv([{ a: 1, secret: 'leaked' }], [
+      { key: 'a', label: 'A' },
+    ]);
+
+    expect(csv).toBe('\uFEFFA\r\n1');
+    expect(csv).not.toContain('leaked');
+    expect(csv).not.toContain('secret');
+  });
+
+  it('matches the UAAM export column order snapshot', () => {
+    const csv = buildCsv([
+      {
+        name: 'Alice',
+        email: 'alice@example.com',
+        mindset: 0,
+        literacy: 80,
+        competency: 75,
+        impact: 90,
+        v1: 'none',
+        v2: 'warning',
+        v3: 'critical',
+        bias_level: 5,
+        bias_message: 'needs review',
+        type_name: '天地型',
+        uaamUpdatedAt: '2026-05-01',
+      },
+      {
+        name: 'Bob',
+        email: 'bob@example.com',
+        mindset: '',
+        literacy: '',
+        competency: '',
+        impact: '',
+        v1: 'none',
+        v2: 'none',
+        v3: 'none',
+        bias_level: 1,
+        bias_message: '',
+        type_name: '未分類',
+        uaamUpdatedAt: '',
+      },
+    ], UAAM_EXPORT_FIELD_DEFS);
+
+    expect(csv).toMatchSnapshot();
+  });
+});

--- a/tests/utils/uaamExportFields.test.js
+++ b/tests/utils/uaamExportFields.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { buildCsv } from '../../src/utils/exportCsv.js';
+import { buildUaamRows, UAAM_EXPORT_FIELD_DEFS } from '../../src/utils/uaamExport.js';
+
+function makeUser(overrides = {}) {
+  return {
+    name: 'User',
+    email: 'user@example.com',
+    scores: {
+      mindset: { total: 40, max: 80, percentage: 50 },
+      literacy: { total: 48, max: 80, percentage: 60 },
+      competency: { total: 56, max: 80, percentage: 70 },
+      impact: { total: 64, max: 80, percentage: 80 },
+    },
+    vAnswers: {},
+    analysis: { type_name: '天地型' },
+    uaamUpdatedAt: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function csvCell(csv, rowIndex, columnIndex) {
+  return csv.split('\r\n')[rowIndex].split(',')[columnIndex];
+}
+
+describe('UAAM export field extraction', () => {
+  it('preserves a falsy 0 percentage as the CSV cell value', () => {
+    const rows = buildUaamRows([
+      makeUser({
+        scores: {
+          mindset: { total: 40, max: 80, percentage: 0 },
+          literacy: { total: 48, max: 80, percentage: 60 },
+          competency: { total: 56, max: 80, percentage: 70 },
+          impact: { total: 64, max: 80, percentage: 80 },
+        },
+      }),
+    ]);
+    const csv = buildCsv(rows, UAAM_EXPORT_FIELD_DEFS);
+
+    expect(csvCell(csv, 1, 2)).toBe('0');
+  });
+
+  it('falls back when percentage is null', () => {
+    const rows = buildUaamRows([
+      makeUser({
+        scores: {
+          mindset: { total: 20, max: 80, percentage: null },
+          literacy: { total: 48, max: 80, percentage: 60 },
+          competency: { total: 56, max: 80, percentage: 70 },
+          impact: { total: 64, max: 80, percentage: 80 },
+        },
+      }),
+    ]);
+
+    expect(rows[0].mindset).toBe(25);
+  });
+
+  it('falls back when percentage is undefined', () => {
+    const rows = buildUaamRows([
+      makeUser({
+        scores: {
+          mindset: { total: 60, max: 80, percentage: undefined },
+          literacy: { total: 48, max: 80, percentage: 60 },
+          competency: { total: 56, max: 80, percentage: 70 },
+          impact: { total: 64, max: 80, percentage: 80 },
+        },
+      }),
+    ]);
+
+    expect(rows[0].mindset).toBe(75);
+  });
+
+  it('uses max || 1 when max is 0 and percentage is absent', () => {
+    const rows = buildUaamRows([
+      makeUser({
+        scores: {
+          mindset: { total: 12, max: 0 },
+          literacy: { total: 48, max: 80, percentage: 60 },
+          competency: { total: 56, max: 80, percentage: 70 },
+          impact: { total: 64, max: 80, percentage: 80 },
+        },
+      }),
+    ]);
+
+    expect(rows[0].mindset).toBe(1200);
+    expect(Number.isFinite(rows[0].mindset)).toBe(true);
+  });
+
+  it('renders all four axis cells as empty strings when scores is null', () => {
+    const rows = buildUaamRows([makeUser({ scores: null })]);
+
+    expect(rows[0].mindset).toBe('');
+    expect(rows[0].literacy).toBe('');
+    expect(rows[0].competency).toBe('');
+    expect(rows[0].impact).toBe('');
+  });
+
+  it('does not leak coaching answers into the CSV', () => {
+    const rows = buildUaamRows([
+      makeUser({
+        coaching_answers: { q1: 'secret_answer' },
+      }),
+    ]);
+    const csv = buildCsv(rows, UAAM_EXPORT_FIELD_DEFS);
+
+    expect(csv).not.toContain('secret_answer');
+    expect(csv).not.toContain('coaching_answers');
+  });
+});

--- a/tests/utils/uaamExportFields.test.js
+++ b/tests/utils/uaamExportFields.test.js
@@ -95,6 +95,30 @@ describe('UAAM export field extraction', () => {
     expect(rows[0].impact).toBe('');
   });
 
+  it('recomputes bias_message for legacy users (undefined) via calculateBiasMessage', () => {
+    const rows = buildUaamRows([
+      makeUser({
+        bias_message: undefined,
+        vAnswers: { V1: 1, V2: 2, V3: 1 },
+        scores: {
+          mindset: { total: 20, max: 80, percentage: 25 },
+          literacy: { total: 24, max: 80, percentage: 30 },
+          competency: { total: 28, max: 80, percentage: 35 },
+          impact: { total: 32, max: 80, percentage: 40 },
+        },
+      }),
+    ]);
+
+    expect(rows[0].bias_message).not.toBe('');
+    expect(typeof rows[0].bias_message).toBe('string');
+  });
+
+  it('preserves explicit null bias_message (healthy) as empty CSV cell', () => {
+    const rows = buildUaamRows([makeUser({ bias_message: null })]);
+
+    expect(rows[0].bias_message).toBe('');
+  });
+
   it('does not leak coaching answers into the CSV', () => {
     const rows = buildUaamRows([
       makeUser({

--- a/vitest.ui.config.js
+++ b/vitest.ui.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
     setupFiles: ['tests/setup.js'],
     include: [
       'tests/*.test.{js,jsx,mjs,ts,tsx}',
+      'tests/utils/**/*.test.{js,jsx,mjs,ts,tsx}',
       'src/**/__tests__/*.test.{js,jsx,ts,tsx}',
       'src/**/*.test.{js,jsx,ts,tsx}',
     ],


### PR DESCRIPTION
## 概要

管理画面の UAAM 診断タブに CSV エクスポート機能を追加（Issue #87）。

## 変更内容

- **クライアント側 CSV 生成**: 追加 Firestore Read ゼロ、追加 API ゼロ
- `src/utils/exportCsv.js`: 汎用 CSV ビルダー（allowlist 方式、BOM 付き UTF-8、RFC 4180 エスケープ）と DOM ダウンロードヘルパー
- `src/utils/uaamExport.js`: UAAM 用フィールド定義と `buildUaamRows`
- `src/screens/AdminScreen.jsx`: UAAM タブヘッダーに「CSVエクスポート」ボタン追加（既存 saikaku ボタンと同スタイル）
- `api/admin/users.js`: `bias_message` の passthrough 追加（既存 Firestore データを 1 行追加）

### CSV 漏洩防止 (Round 2 Critical)

- `buildCsv(rows, fieldDefs)` は **allowlist 方式**（fieldDefs に明示された key のみ抽出）
- スプレッド構文 `...row` / `Object.values(row)` 等の全フィールドダンプは禁止
- 漏洩テスト: `coaching_answers: { q1: 'secret_answer' }` を mock 注入し CSV 出力に `secret_answer` が含まれないことを assert

### 出力カラム

名前 / メール / 志(%) / 知(%) / 技(%) / 衝(%) / V1 / V2 / V3 / bias_level / bias_message / タイプ名 / 診断日

`scores.percentage` の nullish coalescing は falsy 0 を保持。`getVFlags` は UI 表示 (`🏴` / `🏴🏴`) と同じソースを使用。

## テスト

- `npm run test -- exportCsv` → 6 passed (header / quote / BOM / null / allowlist / snapshot)
- `npm run test -- uaamExportFields` → 6 passed (5 境界値 + 漏洩防止)
- `npm run test:e2e -- admin-uaam-export` → 1 passed (Firebase emulator で実行)
- `npm run build` → clean

## レビュー観点

- (a) `getVFlags` 出力が UI 表示 (🏴 / 🏴🏴) と CSV 値で意味的に一致
- (b) `uaamUsers` 全件エクスポート（フィルタ適用なし、既存 saikaku export と同じ挙動）
- (c) コーチング回答本文が CSV に紛れ込まない（allowlist + 漏洩テスト）
- (d) ボタンスタイル・配置が saikaku タブと一致

## 関連

- Issue: #87
- 順次 PR の 1/3: 次は PR-B (#88 統合分析 CSV)、PR-C (#89 統合分析タブ 検索)
- 計画: `plans/issues-87-88-89-uaam-integration-export-search.md`
- ディベート fact-check: `debate/plan-debate-20260511-issues-87-88-89/round-2-fact-check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)