### PR TITLE
feat(uaam): 履歴詳細画面でも recent integration インラインリスト表示 (#90)

### DIFF
--- a/api/lib/recentIntegrationSummaries.js
+++ b/api/lib/recentIntegrationSummaries.js
@@ -1,0 +1,54 @@
+import { responseStatusForIntegration } from './integrationStatus.js';
+import { timestampToMillis } from '../../shared/attemptLogic.js';
+import { buildPairKey } from '../../shared/integrationsKey.js';
+
+export function integrationSummary(integrationDoc, latestIds) {
+  if (!integrationDoc?.integration) return null;
+
+  const body = integrationDoc.integration;
+  const integrationScore = typeof body.integration_score === 'number'
+    ? body.integration_score
+    : null;
+  const activationCore = typeof body.activation_core === 'string'
+    ? body.activation_core
+    : null;
+
+  return {
+    exists: true,
+    generatedAt: integrationDoc.updatedAt ?? integrationDoc.createdAt ?? null,
+    integrationScore,
+    activationCore,
+    saikakuAttemptId: integrationDoc.saikakuAttemptId,
+    uaamAttemptId: integrationDoc.uaamAttemptId,
+    status: responseStatusForIntegration(integrationDoc, 'uaam', latestIds),
+    regenerationCount: integrationDoc.regenerationCount ?? 0,
+    source: integrationDoc.source ?? null,
+    integration: body,
+  };
+}
+
+export function recentIntegrationSummary(integrationDoc, latestIds) {
+  const summary = integrationSummary(integrationDoc, latestIds);
+  if (!summary) return null;
+  if (integrationDoc?.isLegacyFallback === true) {
+    return { ...summary, isLegacyFallback: true };
+  }
+  return summary;
+}
+
+export function compareRecentIntegrationSummaries(a, b) {
+  const aTime = timestampToMillis(a?.generatedAt) ?? Number.NEGATIVE_INFINITY;
+  const bTime = timestampToMillis(b?.generatedAt) ?? Number.NEGATIVE_INFINITY;
+  if (aTime !== bTime) return bTime - aTime;
+  // generatedAt ties use ASC pairKey ordering so Firestore return order cannot affect rows.
+  return buildPairKey(a.saikakuAttemptId, a.uaamAttemptId)
+    .localeCompare(buildPairKey(b.saikakuAttemptId, b.uaamAttemptId));
+}
+
+export function recentIntegrationSummaries(integrations, latestIds) {
+  return integrations
+    .map((integrationDoc) => recentIntegrationSummary(integrationDoc, latestIds))
+    .filter(Boolean)
+    .sort(compareRecentIntegrationSummaries)
+    .slice(0, 2);
+}

--- a/api/me/history/[id].js
+++ b/api/me/history/[id].js
@@ -1,5 +1,7 @@
 import { db } from '../../lib/firebaseAdmin.js';
 import { backfillAttemptSummary, getKindConfig, legacyDocToAttempt } from '../../lib/legacy.js';
+import { listIntegrationDocs } from '../../lib/legacyIntegration.js';
+import { recentIntegrationSummaries } from '../../lib/recentIntegrationSummaries.js';
 import { serializeTimestamps } from '../../lib/serialize.js';
 import { authenticateMeRequest, withMeHandler } from '../_auth.js';
 import { isValidAttemptId } from '../../../shared/attemptLogic.js';
@@ -9,7 +11,7 @@ function readSingleQueryValue(value) {
 }
 
 function attemptDetail(docSnap, kind) {
-  const data = docSnap.data() || {};
+  const data = docSnap.data() ?? {};
   return {
     id: docSnap.id,
     status: data.status ?? null,
@@ -19,6 +21,22 @@ function attemptDetail(docSnap, kind) {
     createdAt: data.createdAt ?? null,
     isLegacy: !!data.isLegacy,
   };
+}
+
+function uaamRecentIntegrationSummaries(parentSnap, integrationsSnap, saikakuParentSnap) {
+  if (!parentSnap?.exists) return [];
+
+  const parentData = parentSnap.data() ?? {};
+  const latestIds = {
+    saikakuAttemptId: saikakuParentSnap?.exists
+      ? saikakuParentSnap.data()?.latestAttemptId ?? null
+      : null,
+    uaamAttemptId: parentData.latestAttemptId ?? null,
+  };
+  return recentIntegrationSummaries(
+    listIntegrationDocs(integrationsSnap, parentData),
+    latestIds,
+  );
 }
 
 export default withMeHandler(async function handler(req, res) {
@@ -38,19 +56,48 @@ export default withMeHandler(async function handler(req, res) {
   }
 
   const parentRef = db.collection(config.collection).doc(decoded.uid);
+  const isUaam = kind === 'uaam';
 
   if (id === 'legacy-fallback') {
-    const parentSnap = await parentRef.get();
+    const [parentSnap, integrationsSnap, saikakuParentSnap] = isUaam
+      ? await Promise.all([
+        parentRef.get(),
+        parentRef.collection('integrations').get(),
+        db.collection('results').doc(decoded.uid).get(),
+      ])
+      : [await parentRef.get(), null, null];
     const legacy = parentSnap.exists ? legacyDocToAttempt(parentSnap.data(), kind) : null;
     if (!legacy) return res.status(404).json({ error: 'attempt not found', code: 'not_found' });
+    if (isUaam) {
+      legacy.recentIntegrationSummaries = uaamRecentIntegrationSummaries(
+        parentSnap,
+        integrationsSnap,
+        saikakuParentSnap,
+      );
+    }
     return res.status(200).json(serializeTimestamps(legacy));
   }
 
-  const attemptSnap = await parentRef.collection('attempts').doc(id).get();
+  const attemptRef = parentRef.collection('attempts').doc(id);
+  const attemptSnap = await attemptRef.get();
   if (!attemptSnap.exists) return res.status(404).json({ error: 'attempt not found', code: 'not_found' });
   if (attemptSnap.data()?.status !== 'committed') {
     return res.status(404).json({ error: 'attempt not found', code: 'not_found' });
   }
 
-  return res.status(200).json(serializeTimestamps(attemptDetail(attemptSnap, kind)));
+  const response = attemptDetail(attemptSnap, kind);
+  if (isUaam) {
+    const [parentSnap, integrationsSnap, saikakuParentSnap] = await Promise.all([
+      parentRef.get(),
+      parentRef.collection('integrations').get(),
+      db.collection('results').doc(decoded.uid).get(),
+    ]);
+    response.recentIntegrationSummaries = uaamRecentIntegrationSummaries(
+      parentSnap,
+      integrationsSnap,
+      saikakuParentSnap,
+    );
+  }
+
+  return res.status(200).json(serializeTimestamps(response));
 });

--- a/api/me/uaam-result.js
+++ b/api/me/uaam-result.js
@@ -1,9 +1,9 @@
 import { db } from '../lib/firebaseAdmin.js';
 import { isLegacyFallback, listIntegrationDocs } from '../lib/legacyIntegration.js';
-import { responseStatusForIntegration } from '../lib/integrationStatus.js';
+import { integrationSummary, recentIntegrationSummaries } from '../lib/recentIntegrationSummaries.js';
 import { serializeTimestamps } from '../lib/serialize.js';
 import { authenticateMeRequest, withMeHandler } from './_auth.js';
-import { isValidAttemptId, selectIntegrationForAttempt, timestampToMillis } from '../../shared/attemptLogic.js';
+import { isValidAttemptId, selectIntegrationForAttempt } from '../../shared/attemptLogic.js';
 
 function readSingleQueryValue(value) {
   return Array.isArray(value) ? value[0] : value;
@@ -16,31 +16,6 @@ function readAttemptId(req) {
     return undefined;
   }
   return value;
-}
-
-function integrationSummary(integrationDoc, latestIds) {
-  if (!integrationDoc?.integration) return null;
-
-  const body = integrationDoc.integration;
-  const integrationScore = typeof body.integration_score === 'number'
-    ? body.integration_score
-    : null;
-  const activationCore = typeof body.activation_core === 'string'
-    ? body.activation_core
-    : null;
-
-  return {
-    exists: true,
-    generatedAt: integrationDoc.updatedAt ?? integrationDoc.createdAt ?? null,
-    integrationScore,
-    activationCore,
-    saikakuAttemptId: integrationDoc.saikakuAttemptId,
-    uaamAttemptId: integrationDoc.uaamAttemptId,
-    status: responseStatusForIntegration(integrationDoc, 'uaam', latestIds),
-    regenerationCount: integrationDoc.regenerationCount ?? 0,
-    source: integrationDoc.source ?? null,
-    integration: body,
-  };
 }
 
 function legacyFallbackIntegration(integrations) {
@@ -58,30 +33,6 @@ function selectUaamIntegration(integrations, attemptId, attemptIsLegacy) {
   // integration を attach しない（PR #60 P2 対応）。
   if (attemptIsLegacy) return legacyFallbackIntegration(integrations);
   return null;
-}
-
-function recentIntegrationSummary(integrationDoc, latestIds) {
-  const summary = integrationSummary(integrationDoc, latestIds);
-  if (!summary) return null;
-  if (integrationDoc?.isLegacyFallback === true) {
-    return { ...summary, isLegacyFallback: true };
-  }
-  return summary;
-}
-
-function compareRecentIntegrationSummaries(a, b) {
-  const aTime = timestampToMillis(a?.generatedAt) ?? Number.NEGATIVE_INFINITY;
-  const bTime = timestampToMillis(b?.generatedAt) ?? Number.NEGATIVE_INFINITY;
-  if (aTime !== bTime) return bTime - aTime;
-  return 0;
-}
-
-function recentIntegrationSummaries(integrations, latestIds) {
-  return integrations
-    .map((integrationDoc) => recentIntegrationSummary(integrationDoc, latestIds))
-    .filter(Boolean)
-    .sort(compareRecentIntegrationSummaries)
-    .slice(0, 2);
 }
 
 function emptyResult(includeIntegrationSummary, recent = []) {
@@ -106,13 +57,28 @@ export default withMeHandler(async function handler(req, res) {
 
   const parentRef = db.collection('uaam_results').doc(decoded.uid);
   const saikakuParentRef = db.collection('results').doc(decoded.uid);
+  let attemptData = null;
+  let attemptIsLegacy = false;
+
+  if (requestedAttemptId) {
+    // attemptId 指定時は、まず軽量な attempt doc だけを検証する。
+    // 存在しない attempt で parent/integrations の重い補助 read を起動しない。
+    const attemptSnap = await parentRef.collection('attempts').doc(requestedAttemptId).get();
+    if (!attemptSnap.exists || attemptSnap.data()?.status !== 'committed') {
+      return res.status(404).json({ error: 'attempt not found', code: 'not_found' });
+    }
+
+    attemptData = attemptSnap.data() ?? {};
+    attemptIsLegacy = !!attemptData.isLegacy;
+  }
+
   const [snapshot, saikakuParentSnap, integrationsSnap] = await Promise.all([
     parentRef.get(),
     saikakuParentRef.get(),
     parentRef.collection('integrations').get(),
   ]);
 
-  const data = snapshot.exists ? (snapshot.data() || {}) : null;
+  const data = snapshot.exists ? (snapshot.data() ?? {}) : null;
   const integrations = listIntegrationDocs(integrationsSnap, data);
   const latestSaikakuAttemptId = saikakuParentSnap.exists
     ? saikakuParentSnap.data()?.latestAttemptId ?? null
@@ -134,19 +100,8 @@ export default withMeHandler(async function handler(req, res) {
 
   let scores = data.scores ?? null;
   let analysis = data.analysis ?? null;
-  let attemptIsLegacy = false;
 
   if (requestedAttemptId) {
-    // legacy-fallback も他の attemptId と同様に existence check を要求する。
-    // この仮想 ID は read 内の integration synthesis 用であり、実 attempt として
-    // クライアント送信されるべきではない（migration 後は legacy-v1 が実 ID）。
-    const attemptSnap = await parentRef.collection('attempts').doc(requestedAttemptId).get();
-    if (!attemptSnap.exists || attemptSnap.data()?.status !== 'committed') {
-      return res.status(404).json({ error: 'attempt not found', code: 'not_found' });
-    }
-
-    const attemptData = attemptSnap.data();
-    attemptIsLegacy = !!attemptData?.isLegacy;
     const full = attemptData?.full ?? {};
     scores = full.scores ?? null;
     analysis = full.analysis ?? null;

--- a/docs/spec/integrations-schema.md
+++ b/docs/spec/integrations-schema.md
@@ -78,11 +78,12 @@ All fields are top-level fields. They are not nested under `analysis`.
   - For `kind='saikaku'`: returns ALL integrations whose `saikakuAttemptId === attemptId` as an array, same sort order.
 - Sort is deterministic — Firestore document order is NOT guaranteed.
 
-## Recent Integration Summaries (issue #81)
+## Recent Integration Summaries (issue #81 / #90)
 
 - `/api/me/uaam-result` レスポンスに `recentIntegrationSummaries: SummaryShape[]` を**常に**含める。
-- 構築フロー（`api/me/uaam-result.js`）:
-  1. 既取得の `integrationsSnap` (= `listIntegrationDocs(integrationsSnap, data)`) を再利用し、追加の Firestore read は発生させない。
+- `/api/me/history/[id]?kind=uaam` レスポンスにも同じ shape の `recentIntegrationSummaries` を含める。`kind=saikaku` ではこのフィールドを含めない。
+- 構築フロー（共有 builder: `api/lib/recentIntegrationSummaries.js`）:
+  1. `/api/me/uaam-result` は既取得の `integrationsSnap` (= `listIntegrationDocs(integrationsSnap, data)`) を再利用し、追加の Firestore read は発生させない。`/api/me/history/[id]?kind=uaam` は attempt read と並列で UAAM parent / integrations / Saikaku parent を読む。
   2. 各 doc に `integrationSummary(doc, latestIds)` を適用する。**body 欠損 doc は `null` を返す既存仕様を保持**。
   3. `.filter(Boolean)` で null を除外。
   4. `generatedAt` (= `updatedAt ?? createdAt`) で**降順 client-side sort** (`timestampToMillis` で正規化、null は `-Infinity` 扱い)。Firestore `orderBy` は使わない (PR #72 [P2] 踏襲)。
@@ -91,11 +92,13 @@ All fields are top-level fields. They are not nested under `analysis`.
 - レスポンスの `serializeTimestamps` を必ず通すこと（Timestamp → ISO 8601 文字列）。
 - `recentIntegrationSummaries[].integration` に**統合分析本体を同梱**する（UI 側 modal で表示するため）。レスポンス payload 増加は 2件分 = 数KB で許容範囲。
 - 0件 (subcollection 空 / 全 body 欠損) のときは `[]` を返す。
+- UAAM parent doc が存在しない場合、orphaned subcollection integrations は露出せず `[]` を返す。
 
 ### UI consumer responsibility (`src/screens/uaam/UAAMResultScreen.jsx`)
 
 - `effectiveResult?.recentIntegrationSummaries ?? []` で読み取る（旧キャッシュ shape 防御）。
-- `analysis.saikaku_integration?.integration_score === undefined` の **else 分岐**（生成ボタン表示状態）でのみ描画。`isHistoryView` (= `attemptData` あり) では描画しない。
+- history view は `attemptToResultProps(attemptData, 'uaam')` が `attempt.recentIntegrationSummaries ?? null` を `result.recentIntegrationSummaries` に bridge する。
+- `analysis.saikaku_integration?.integration_score === undefined` の **else 分岐**（生成ボタン表示状態）で live view / history view ともに描画する。
 - 行クリック / Enter / Space → `SaikakuIntegrationModal` を `kind="uaam"` + 単数 summary 渡しで起動。
 
 ## Migration Script

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,9 +4,9 @@
 
 | 層 | コマンド | カバレッジ | 所要時間 |
 |----|----------|------------|----------|
-| Unit | `npm run test:unit` | バッジ表示ロジック / attemptAdapter / AdminScreen 統合分析タブ / UAAMResultScreen 最近の統合分析リスト (80 tests) | < 5 秒 |
+| Unit | `npm run test:unit` | バッジ表示ロジック / attemptAdapter / AdminScreen 統合分析タブ / UAAMResultScreen 最近の統合分析リスト (90 tests) | < 10 秒 |
 | Rules | `npm run test:rules` | Firestore rules 21 シナリオ (`/api/me/*` 経由化で attempts/uaam_results parent の read deny を反転検証) | 〜2 秒 |
-| API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency + `/api/me/*` BFF + `/api/admin/integrations` (126 tests) | 〜30 秒 |
+| API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency + `/api/me/*` BFF + `/api/admin/integrations` (134 tests) | 〜30 秒 |
 | E2E | `npm run test:e2e` | Playwright 39 フロー (badge/history/limit/admin-integrations/uaam-recent-integrations 等) | 〜170 秒 |
 | **All** | `npm run test:all` | 全部直列実行 | 〜210 秒 |
 

--- a/src/screens/uaam/UAAMResultScreen.jsx
+++ b/src/screens/uaam/UAAMResultScreen.jsx
@@ -2080,7 +2080,7 @@ export default function UAAMResultScreen({ user, result, attemptData, isAdmin, o
     return { axis, data: order.map(k => subs[k] || 0), labels: order.map(k => SUB_LABELS[k]), order };
   });
   const recentIntegrationSummaries = effectiveResult?.recentIntegrationSummaries ?? [];
-  const visibleRecentIntegrationSummaries = !isHistoryView && Array.isArray(recentIntegrationSummaries)
+  const visibleRecentIntegrationSummaries = Array.isArray(recentIntegrationSummaries)
     ? recentIntegrationSummaries.slice(0, 2)
     : [];
   const integrationSource = integrationSourceFromSummary(integrationSummary, analysis);

--- a/src/utils/attemptAdapter.js
+++ b/src/utils/attemptAdapter.js
@@ -40,6 +40,7 @@ export function attemptToResultProps(attempt, kind) {
       // ActivationPanel が `第${coachConfirmed.leadership_stage}` のように scalar として参照するため正規化しない
       coach_confirmed_leadership_stage: attempt.full?.coach_confirmed_leadership_stage ?? null,
       coach_observation_note: attempt.full?.coach_observation_note ?? null,
+      recentIntegrationSummaries: attempt.recentIntegrationSummaries ?? null,
     },
   };
 }

--- a/tests/api/me-history-detail.test.js
+++ b/tests/api/me-history-detail.test.js
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { db } from '../../api/lib/firebaseAdmin.js';
+import { buildPairKey } from '../../shared/integrationsKey.js';
 import {
   Timestamp,
   api,
@@ -7,6 +8,124 @@ import {
   seedAttempt,
   seedParent,
 } from './_helpers.js';
+
+function at(day) {
+  return Timestamp.fromDate(new Date(`2026-05-0${day}T00:00:00.000Z`));
+}
+
+function uaamScores() {
+  return {
+    mindset: { total: 60 },
+    literacy: { total: 62 },
+    competency: { total: 64 },
+    impact: { total: 66 },
+  };
+}
+
+function uaamAnalysis(overrides = {}) {
+  return {
+    type_name: 'History UAAM',
+    narrative: 'history analysis',
+    ...overrides,
+  };
+}
+
+function integrationBody(score, activationCore) {
+  return {
+    integration_score: score,
+    activation_core: activationCore,
+    activation_equation: `${activationCore} equation`,
+  };
+}
+
+async function clearIntegrationDocs(uid) {
+  const snap = await db.collection('uaam_results').doc(uid).collection('integrations').get();
+  if (snap.empty) return;
+
+  const batch = db.batch();
+  snap.docs.forEach((docSnap) => batch.delete(docSnap.ref));
+  await batch.commit();
+}
+
+async function clearAllUserState(uid) {
+  await clearIntegrationDocs(uid);
+  await Promise.all([
+    clearUserState('results', uid),
+    clearUserState('uaam_results', uid),
+  ]);
+}
+
+async function seedUaamReadyUser(uid, attemptId = 'uaam-history') {
+  await clearAllUserState(uid);
+  await Promise.all([
+    seedParent('results', uid, {
+      latestAttemptId: 'saikaku-current',
+      selectedKakuchiiki: 'Saikaku Current',
+      result: { kakuchiiki: 'Saikaku Current' },
+      createdAt: at(1),
+    }),
+    seedParent('uaam_results', uid, {
+      latestAttemptId: 'uaam-current',
+      scores: uaamScores(),
+      analysis: uaamAnalysis(),
+      createdAt: at(1),
+    }),
+    seedAttempt('uaam_results', uid, attemptId, {
+      status: 'committed',
+      createdAt: at(1),
+      summary: { typeName: 'History UAAM', createdAt: at(1) },
+      full: {
+        scores: uaamScores(),
+        analysis: uaamAnalysis(),
+        name: 'History User',
+      },
+      raw: { input: { answers: { 1: 3 }, vAnswers: { V1: 4 } } },
+    }),
+  ]);
+}
+
+async function seedIntegration(uid, saikakuAttemptId, uaamAttemptId, overrides = {}) {
+  const pairKey = buildPairKey(saikakuAttemptId, uaamAttemptId);
+  const doc = {
+    saikakuAttemptId,
+    uaamAttemptId,
+    regenerationCount: overrides.regenerationCount ?? 0,
+    model: 'test-model',
+    source: {
+      saikakuLabel: `Saikaku ${saikakuAttemptId}`,
+      uaamLabel: `UAAM ${uaamAttemptId}`,
+    },
+    status: 'active',
+    createdAt: overrides.createdAt ?? at(1),
+    updatedAt: overrides.updatedAt ?? overrides.createdAt ?? at(1),
+  };
+  if (!overrides.omitIntegration) {
+    doc.integration = overrides.integration ?? integrationBody(88, 'Active Core');
+  }
+  await db.collection('uaam_results').doc(uid).collection('integrations').doc(pairKey).set(doc);
+}
+
+function mockSupportingReadsFail(uid) {
+  const parentRef = db.collection('uaam_results').doc(uid);
+  const saikakuParentRef = db.collection('results').doc(uid);
+  const integrationsRef = parentRef.collection('integrations');
+  const docGet = Object.getPrototypeOf(parentRef).get;
+  const collectionGet = Object.getPrototypeOf(integrationsRef).get;
+
+  vi.spyOn(Object.getPrototypeOf(parentRef), 'get').mockImplementation(function get(...args) {
+    if (this.path === parentRef.path || this.path === saikakuParentRef.path) {
+      throw new Error(`supporting doc read should not run: ${this.path}`);
+    }
+    return docGet.apply(this, args);
+  });
+
+  vi.spyOn(Object.getPrototypeOf(integrationsRef), 'get').mockImplementation(function get(...args) {
+    if (this.path === integrationsRef.path) {
+      throw new Error(`supporting integration read should not run: ${this.path}`);
+    }
+    return collectionGet.apply(this, args);
+  });
+}
 
 describe('API /api/me/history/:id', () => {
   afterEach(() => {
@@ -122,6 +241,169 @@ describe('API /api/me/history/:id', () => {
     expect(response.body).toEqual({
       code: 'internal_error',
       requestId: expect.any(String),
+    });
+  });
+
+  describe('UAAM recentIntegrationSummaries', () => {
+    it('returns [] when there are no integration docs', async () => {
+      const uid = 'u-me-history-detail-recent-none';
+      await seedUaamReadyUser(uid);
+
+      const response = await api.get('/api/me/history/uaam-history?kind=uaam').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toEqual([]);
+    });
+
+    it('returns 404 for a missing attempt before supporting reads can fail', async () => {
+      const uid = 'u-me-history-detail-recent-missing-short-circuit';
+      await clearAllUserState(uid);
+      mockSupportingReadsFail(uid);
+
+      const response = await api.get('/api/me/history/missing-attempt?kind=uaam').set('x-test-uid', uid);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: 'attempt not found', code: 'not_found' });
+    });
+
+    it('returns the latest two summaries in generatedAt descending order with bodies and excludes body-missing docs', async () => {
+      const uid = 'u-me-history-detail-recent-latest-two';
+      await seedUaamReadyUser(uid);
+      await seedIntegration(uid, 'saikaku-old-a', 'uaam-old-a', {
+        integration: integrationBody(71, 'Old Core'),
+        updatedAt: at(1),
+      });
+      await seedIntegration(uid, 'saikaku-old-b', 'uaam-old-b', {
+        integration: integrationBody(93, 'Newest Core'),
+        regenerationCount: 1,
+        updatedAt: at(3),
+      });
+      await seedIntegration(uid, 'saikaku-old-c', 'uaam-old-c', {
+        integration: integrationBody(82, 'Middle Core'),
+        updatedAt: at(2),
+      });
+      await seedIntegration(uid, 'saikaku-old-d', 'uaam-old-d', {
+        omitIntegration: true,
+        updatedAt: at(4),
+      });
+
+      const response = await api.get('/api/me/history/uaam-history?kind=uaam').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toHaveLength(2);
+      expect(response.body.recentIntegrationSummaries.map((item) => item.generatedAt)).toEqual([
+        '2026-05-03T00:00:00.000Z',
+        '2026-05-02T00:00:00.000Z',
+      ]);
+      expect(response.body.recentIntegrationSummaries).toEqual([
+        expect.objectContaining({
+          exists: true,
+          integrationScore: 93,
+          activationCore: 'Newest Core',
+          saikakuAttemptId: 'saikaku-old-b',
+          uaamAttemptId: 'uaam-old-b',
+          status: 'stale',
+          regenerationCount: 1,
+          source: { saikakuLabel: 'Saikaku saikaku-old-b', uaamLabel: 'UAAM uaam-old-b' },
+          integration: integrationBody(93, 'Newest Core'),
+        }),
+        expect.objectContaining({
+          exists: true,
+          integrationScore: 82,
+          activationCore: 'Middle Core',
+          saikakuAttemptId: 'saikaku-old-c',
+          uaamAttemptId: 'uaam-old-c',
+          status: 'stale',
+          regenerationCount: 0,
+          source: { saikakuLabel: 'Saikaku saikaku-old-c', uaamLabel: 'UAAM uaam-old-c' },
+          integration: integrationBody(82, 'Middle Core'),
+        }),
+      ]);
+      expect(response.body.recentIntegrationSummaries).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ uaamAttemptId: 'uaam-old-d' }),
+        ]),
+      );
+    });
+
+    it('returns [] when the UAAM parent doc is missing even if orphaned subcollection docs exist', async () => {
+      const uid = 'u-me-history-detail-recent-parent-missing';
+      await clearAllUserState(uid);
+      await seedAttempt('uaam_results', uid, 'uaam-history', {
+        status: 'committed',
+        createdAt: at(1),
+        summary: { typeName: 'History UAAM', createdAt: at(1) },
+        full: {
+          scores: uaamScores(),
+          analysis: uaamAnalysis(),
+        },
+        raw: { input: { answers: { 1: 3 }, vAnswers: { V1: 4 } } },
+      });
+      await seedIntegration(uid, 'saikaku-orphan', 'uaam-orphan', {
+        integration: integrationBody(91, 'Orphan Core'),
+        updatedAt: at(2),
+      });
+
+      const response = await api.get('/api/me/history/uaam-history?kind=uaam').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toEqual([]);
+    });
+
+    it('includes a legacy fallback summary on the legacy-fallback detail path', async () => {
+      const uid = 'u-me-history-detail-recent-legacy';
+      await clearAllUserState(uid);
+      await seedParent('uaam_results', uid, {
+        scores: uaamScores(),
+        analysis: uaamAnalysis({
+          saikaku_attempt_label: 'Legacy Saikaku',
+          uaam_attempt_label: 'Legacy UAAM',
+          saikaku_integration: integrationBody(77, 'Legacy Core'),
+        }),
+        integrationUpdatedAt: at(3),
+        createdAt: at(1),
+      });
+
+      const response = await api.get('/api/me/history/legacy-fallback?kind=uaam').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body.recentIntegrationSummaries).toEqual([
+        {
+          exists: true,
+          generatedAt: '2026-05-03T00:00:00.000Z',
+          integrationScore: 77,
+          activationCore: 'Legacy Core',
+          saikakuAttemptId: 'legacy-fallback',
+          uaamAttemptId: 'legacy-fallback',
+          status: 'active',
+          regenerationCount: 0,
+          source: { saikakuLabel: 'Legacy Saikaku', uaamLabel: 'Legacy UAAM' },
+          integration: integrationBody(77, 'Legacy Core'),
+          isLegacyFallback: true,
+        },
+      ]);
+    });
+
+    it('does not include recentIntegrationSummaries for saikaku kind', async () => {
+      const uid = 'u-me-history-detail-recent-saikaku-absent';
+      await clearUserState('results', uid);
+      await seedAttempt('results', uid, 'attempt-1', {
+        status: 'committed',
+        createdAt: at(1),
+        summary: { kakuchiiki: '問いに火を灯す人', typeName: null, createdAt: at(1) },
+        full: {
+          result: { kakuchiiki: '問いに火を灯す人', createdAt: at(1) },
+          analysis: null,
+          scores: null,
+          selectedKakuchiiki: '問いに火を灯す人',
+        },
+        raw: { input: {} },
+      });
+
+      const response = await api.get('/api/me/history/attempt-1?kind=saikaku').set('x-test-uid', uid);
+
+      expect(response.status).toBe(200);
+      expect(response.body).not.toHaveProperty('recentIntegrationSummaries');
     });
   });
 });

--- a/tests/api/me-uaam-result.test.js
+++ b/tests/api/me-uaam-result.test.js
@@ -95,6 +95,28 @@ async function seedIntegration(uid, saikakuAttemptId, uaamAttemptId, overrides =
   await db.collection('uaam_results').doc(uid).collection('integrations').doc(pairKey).set(doc);
 }
 
+function mockSupportingReadsFail(uid) {
+  const parentRef = db.collection('uaam_results').doc(uid);
+  const saikakuParentRef = db.collection('results').doc(uid);
+  const integrationsRef = parentRef.collection('integrations');
+  const docGet = Object.getPrototypeOf(parentRef).get;
+  const collectionGet = Object.getPrototypeOf(integrationsRef).get;
+
+  vi.spyOn(Object.getPrototypeOf(parentRef), 'get').mockImplementation(function get(...args) {
+    if (this.path === parentRef.path || this.path === saikakuParentRef.path) {
+      throw new Error(`supporting doc read should not run: ${this.path}`);
+    }
+    return docGet.apply(this, args);
+  });
+
+  vi.spyOn(Object.getPrototypeOf(integrationsRef), 'get').mockImplementation(function get(...args) {
+    if (this.path === integrationsRef.path) {
+      throw new Error(`supporting integration read should not run: ${this.path}`);
+    }
+    return collectionGet.apply(this, args);
+  });
+}
+
 describe('API /api/me/uaam-result', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -183,6 +205,17 @@ describe('API /api/me/uaam-result', () => {
       code: 'internal_error',
       requestId: expect.any(String),
     });
+  });
+
+  it('returns 404 for a missing requested attempt before supporting reads can fail', async () => {
+    const uid = 'u-me-uaam-result-missing-attempt-short-circuit';
+    await clearAllUserState(uid);
+    mockSupportingReadsFail(uid);
+
+    const response = await api.get('/api/me/uaam-result?attemptId=missing-attempt').set('x-test-uid', uid);
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'attempt not found', code: 'not_found' });
   });
 
   describe('recentIntegrationSummaries', () => {

--- a/tests/e2e/uaam-recent-integrations.spec.js
+++ b/tests/e2e/uaam-recent-integrations.spec.js
@@ -202,8 +202,8 @@ test('UAAM result old cache shape without recentIntegrationSummaries does not cr
   await expect(page.getByTestId('recent-integration-0')).toHaveCount(0);
 });
 
-test('UAAM history detail does not render recent integration rows', async ({ page }, testInfo) => {
-  const { email, user } = await createCleanUser('history-empty', testInfo);
+test('UAAM history detail renders recent integration rows and opens modal on click and Enter', async ({ page }, testInfo) => {
+  const { email, user } = await createCleanUser('history-rows-modal', testInfo);
   await seedUserWithRecentIntegrations(user.uid);
 
   await loginAs(page, email, password);
@@ -214,5 +214,22 @@ test('UAAM history detail does not render recent integration rows', async ({ pag
 
   await expect(page.getByText('Unique Ability Activation Matrix').first()).toBeVisible();
   await expect(page.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeVisible();
-  await expect(page.getByTestId('recent-integration-0')).toHaveCount(0);
+  await expect(page.getByTestId('recent-integration-0')).toBeVisible();
+  await expect(page.getByTestId('recent-integration-1')).toBeVisible();
+  await expect(page.getByTestId('recent-integration-2')).toHaveCount(0);
+  await expect(page.getByTestId('recent-integration-0')).toContainText('E2E Recent Core 2');
+  await expect(page.getByTestId('recent-integration-1')).toContainText('E2E Recent Core 1');
+
+  await page.getByTestId('recent-integration-0').click();
+  const dialog = page.getByRole('dialog', { name: '才覚発動統合分析' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('E2E Recent Core 2', { exact: true })).toBeVisible();
+
+  await dialog.getByRole('button', { name: '閉じる' }).click();
+  await expect(dialog).toHaveCount(0);
+
+  await page.getByTestId('recent-integration-1').focus();
+  await page.keyboard.press('Enter');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('E2E Recent Core 1', { exact: true })).toBeVisible();
 });

--- a/tests/unit/adapter.test.js
+++ b/tests/unit/adapter.test.js
@@ -67,6 +67,7 @@ describe('attemptAdapter', () => {
         coach_confirmed_personality_level: 'L5',
         coach_confirmed_leadership_stage: 4,
         coach_observation_note: '観察メモ',
+        recentIntegrationSummaries: null,
       },
     });
   });
@@ -112,5 +113,26 @@ describe('attemptAdapter', () => {
     expect(out.result.leadership_stage).toEqual({ stage: 3, name: '第3段階' });
     expect(out.result.coach_confirmed_leadership_stage).toBe(4);
     expect(out.result.coach_confirmed_personality_level).toBe('L5');
+  });
+
+  it.each([
+    [undefined, null],
+    [[], []],
+    [[{ activationCore: 'Recent Core' }], [{ activationCore: 'Recent Core' }]],
+  ])('bridges UAAM recentIntegrationSummaries %s without collapsing the shape', (input, expected) => {
+    const attempt = {
+      full: { scores: {}, analysis: null },
+      raw: { input: {} },
+    };
+    if (input !== undefined) {
+      attempt.recentIntegrationSummaries = input;
+    }
+
+    const out = attemptToResultProps(attempt, 'uaam');
+
+    expect(out.result.recentIntegrationSummaries).toEqual(expected);
+    if (Array.isArray(input)) {
+      expect(out.result.recentIntegrationSummaries).toBe(input);
+    }
   });
 });

--- a/tests/unit/recentIntegrationSummaries.test.js
+++ b/tests/unit/recentIntegrationSummaries.test.js
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  integrationSummary,
+  recentIntegrationSummaries,
+  recentIntegrationSummary,
+} from '../../api/lib/recentIntegrationSummaries.js';
+import { buildPairKey } from '../../shared/integrationsKey.js';
+
+function integrationBody(score, activationCore) {
+  return {
+    integration_score: score,
+    activation_core: activationCore,
+    activation_equation: `${activationCore} equation`,
+  };
+}
+
+function integrationDoc(overrides = {}) {
+  return {
+    saikakuAttemptId: 'saikaku-current',
+    uaamAttemptId: 'uaam-current',
+    regenerationCount: 0,
+    source: {
+      saikakuLabel: 'Saikaku Current',
+      uaamLabel: 'UAAM Current',
+    },
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+    integration: integrationBody(88, 'Current Core'),
+    ...overrides,
+  };
+}
+
+describe('recentIntegrationSummaries builders', () => {
+  it('builds the UAAM integration summary shape without changing null defaults', () => {
+    const summary = integrationSummary(integrationDoc({
+      integration: {
+        integration_score: 'not-a-number',
+        activation_core: null,
+      },
+      updatedAt: null,
+      createdAt: '2026-05-02T00:00:00.000Z',
+      regenerationCount: undefined,
+      source: undefined,
+    }), {
+      saikakuAttemptId: 'saikaku-current',
+      uaamAttemptId: 'uaam-current',
+    });
+
+    expect(summary).toEqual({
+      exists: true,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      integrationScore: null,
+      activationCore: null,
+      saikakuAttemptId: 'saikaku-current',
+      uaamAttemptId: 'uaam-current',
+      status: 'active',
+      regenerationCount: 0,
+      source: null,
+      integration: {
+        integration_score: 'not-a-number',
+        activation_core: null,
+      },
+    });
+  });
+
+  it('returns null when the integration body is missing', () => {
+    expect(integrationSummary(integrationDoc({ integration: undefined }), {})).toBeNull();
+    expect(recentIntegrationSummary(integrationDoc({ integration: undefined }), {})).toBeNull();
+  });
+
+  it('filters body-missing docs, sorts by generatedAt descending, and limits to two', () => {
+    const summaries = recentIntegrationSummaries([
+      integrationDoc({
+        saikakuAttemptId: 'saikaku-old-a',
+        uaamAttemptId: 'uaam-old-a',
+        integration: integrationBody(71, 'Old Core'),
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      }),
+      integrationDoc({
+        saikakuAttemptId: 'saikaku-old-b',
+        uaamAttemptId: 'uaam-old-b',
+        integration: integrationBody(93, 'Newest Core'),
+        updatedAt: '2026-05-03T00:00:00.000Z',
+      }),
+      integrationDoc({
+        saikakuAttemptId: 'saikaku-old-c',
+        uaamAttemptId: 'uaam-old-c',
+        integration: integrationBody(82, 'Middle Core'),
+        updatedAt: '2026-05-02T00:00:00.000Z',
+      }),
+      integrationDoc({
+        saikakuAttemptId: 'saikaku-old-d',
+        uaamAttemptId: 'uaam-old-d',
+        integration: undefined,
+        updatedAt: '2026-05-04T00:00:00.000Z',
+      }),
+    ], {
+      saikakuAttemptId: 'saikaku-current',
+      uaamAttemptId: 'uaam-current',
+    });
+
+    expect(summaries.map((summary) => summary.activationCore)).toEqual([
+      'Newest Core',
+      'Middle Core',
+    ]);
+    expect(summaries).toEqual([
+      expect.objectContaining({
+        integrationScore: 93,
+        status: 'stale',
+        integration: integrationBody(93, 'Newest Core'),
+      }),
+      expect.objectContaining({
+        integrationScore: 82,
+        status: 'stale',
+        integration: integrationBody(82, 'Middle Core'),
+      }),
+    ]);
+  });
+
+  it('breaks generatedAt ties by pairKey ascending for deterministic ordering', () => {
+    const generatedAt = '2026-05-03T00:00:00.000Z';
+    const summaries = recentIntegrationSummaries([
+      integrationDoc({
+        saikakuAttemptId: 'saikaku-b',
+        uaamAttemptId: 'uaam-a',
+        integration: integrationBody(71, 'Pair B'),
+        updatedAt: generatedAt,
+      }),
+      integrationDoc({
+        saikakuAttemptId: 'saikaku-a',
+        uaamAttemptId: 'uaam-z',
+        integration: integrationBody(93, 'Pair AZ'),
+        updatedAt: generatedAt,
+      }),
+      integrationDoc({
+        saikakuAttemptId: 'saikaku-a',
+        uaamAttemptId: 'uaam-a',
+        integration: integrationBody(82, 'Pair AA'),
+        updatedAt: generatedAt,
+      }),
+    ], {
+      saikakuAttemptId: 'saikaku-current',
+      uaamAttemptId: 'uaam-current',
+    });
+
+    expect(summaries.map((summary) => buildPairKey(
+      summary.saikakuAttemptId,
+      summary.uaamAttemptId,
+    ))).toEqual([
+      'saikaku-a__uaam-a',
+      'saikaku-a__uaam-z',
+    ]);
+  });
+
+  it('preserves the legacy fallback marker on recent summaries', () => {
+    expect(recentIntegrationSummary(integrationDoc({
+      saikakuAttemptId: 'legacy-fallback',
+      uaamAttemptId: 'legacy-fallback',
+      isLegacyFallback: true,
+      integration: integrationBody(77, 'Legacy Core'),
+    }), {})).toEqual(expect.objectContaining({
+      activationCore: 'Legacy Core',
+      status: 'active',
+      isLegacyFallback: true,
+    }));
+  });
+});

--- a/tests/unit/ui/uaam-result-recent-integrations.test.jsx
+++ b/tests/unit/ui/uaam-result-recent-integrations.test.jsx
@@ -150,6 +150,47 @@ function renderScreen(result) {
   );
 }
 
+function attemptDataFromResult(result, overrides = {}) {
+  const attempt = {
+    id: 'attempt-unit-history',
+    status: 'committed',
+    full: {
+      scores: result.scores,
+      analysis: result.analysis,
+      name: result.name,
+      bias_message: result.bias_message,
+      personality_level: result.personality_level,
+      leadership_stage: result.leadership_stage,
+      three_elements: result.three_elements,
+    },
+    raw: {
+      input: {
+        answers: result.answers,
+        vAnswers: result.vAnswers,
+      },
+    },
+    ...overrides,
+  };
+  if (Object.prototype.hasOwnProperty.call(result, 'recentIntegrationSummaries')) {
+    attempt.recentIntegrationSummaries = result.recentIntegrationSummaries;
+  }
+  return attempt;
+}
+
+function renderHistoryScreen(attemptData) {
+  return render(
+    <UAAMResultScreen
+      user={user}
+      result={null}
+      attemptData={attemptData}
+      isAdmin={false}
+      onReset={noop}
+      onAdmin={noop}
+      onLogout={noop}
+    />,
+  );
+}
+
 describe('UAAMResultScreen recent integrations', () => {
   beforeEach(() => {
     coachingMocks.loadCoachingAnswers.mockResolvedValue({});
@@ -177,6 +218,23 @@ describe('UAAMResultScreen recent integrations', () => {
 
   it('does not crash when recentIntegrationSummaries is missing from an old cache shape', () => {
     renderScreen(baseResult());
+
+    expect(screen.queryByTestId('recent-integration-0')).toBeNull();
+    expect(screen.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeInTheDocument();
+  });
+
+  it('renders recent integration rows in history view from attemptData', () => {
+    renderHistoryScreen(attemptDataFromResult(baseResult({
+      recentIntegrationSummaries: [recentSummary(0), recentSummary(1)],
+    })));
+
+    expect(screen.getByTestId('recent-integration-0')).toHaveTextContent('Recent Core 1');
+    expect(screen.getByTestId('recent-integration-1')).toHaveTextContent('Recent Core 2');
+    expect(screen.queryByTestId('recent-integration-2')).toBeNull();
+  });
+
+  it('does not crash in history view when recentIntegrationSummaries is missing from an old cache shape', () => {
+    renderHistoryScreen(attemptDataFromResult(baseResult()));
 
     expect(screen.queryByTestId('recent-integration-0')).toBeNull();
     expect(screen.getByRole('button', { name: /才覚×UAAM 統合発動分析を生成する/ })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

PR #82 (issue #81) で live view (`/uaam/result`) に追加した「最近の統合分析」インライン行リストを、UAAM 履歴詳細画面 (`/history/uaam/{attemptId}` 経由で `attemptData` 由来) でも同じ仕様で描画。

Closes #90.

## 実装方針: 案 B (API 拡張 + Adapter bridge)

debate (Gemini + Claude独立レビュー) で **案 A** (history view から `/api/me/uaam-result` を独立 fetch) を「致命的オーバーフェッチ・責務崩壊」として棄却し、**案 B** を採用。**案 C** (`/api/me/recent-integrations` 軽量専用 endpoint) は将来別 issue 化。

### 変更内容

- **共通 builder**: `api/lib/recentIntegrationSummaries.js` 新設し、`api/me/uaam-result.js` と `api/me/history/[id].js` の両方から再利用 (live と history で shape divergence を構造的に防止)
- **API 拡張**: `/api/me/history/[id]?kind=uaam` レスポンスに `recentIntegrationSummaries: SummaryShape[]` (最大2件 / `generatedAt` 降順 / body 同梱 / body 欠損 doc 除外) を追加
  - saikaku kind には付与しない (`undefined`)
  - UAAM parent doc 不在時は `[]` を返す (PR #82 P2 fix と同じ orphan-suppress 方針)
- **Adapter bridge** (1行): `attemptToResultProps` UAAM 分岐で `result.recentIntegrationSummaries = attempt.recentIntegrationSummaries ?? null`
- **UI ガード除去** (1行): `UAAMResultScreen.jsx` の `!isHistoryView` を `visibleRecentIntegrationSummaries` 定義から削除

### Operator semantics 守備 (Anti-Pattern A)

- adapter は `?? null` (NOT `||`)。空配列 `[]` を `null` に潰さない
- UI は `effectiveResult?.recentIntegrationSummaries ?? []` のみ。`recentSummariesFromApi` のような並列 state は導入しない

## Codex review 指摘対応 (P0 + P1-4)

| 指摘 | 対応 |
|---|---|
| P0: attempt 存在確認の前に integrations 全件 read (軽量 DoS + 500化) | attempt-first sequencing で先に 404 短絡、その後 supporting reads を `Promise.all` 並列化 |
| P1-4: `generatedAt` 同値時 tie-break 未定義 | `compareRecentIntegrationSummaries` に ASC `pairKey` second-key 比較を追加 + unit test |
| P1+: unbounded integrations read / native `<button>` / `MAX_*` re-assignment 等 | 既存問題・別 issue 化 (#90 スコープ外) |
| UX「生成済時も recent 表示」(Codex 誤指摘) | 仕様書通り (`integrations-schema.md`)。else 分岐のみ描画は意図的設計 |
| Data-Deps Critical (history view 生成ボタンが latest pair で動く) | 既存バグ (commit 9ab155ab)、別 issue 化推奨 |

## テスト

| 層 | 件数 | 増分 | 主要追加 |
|---|---|---|---|
| Unit | 11 files / **90 tests** | +10 | pure builder 8 case、adapter bridge `undefined → null` / `[] → []` / `[s1] → [s1]`、UI history view 描画 |
| API | 22 files / **134 tests** | +7 | history detail 6 variant (empty / latest-2 / body-missing-exclude / parent-missing-orphan / legacy fallback / saikaku 不在) + uaam-result short-circuit 1 |
| E2E | **39 Playwright tests** | ±0 | 既存 spec `'history detail does not render recent integration rows'` を `'renders rows and opens modal on click and Enter'` に反転 |

## Test plan

- [x] `npm run test:unit` 全パス (90/90)
- [x] `npm run test:api` 全パス (134/134)
- [x] `npm run test:e2e` 全パス (39/39)
- [x] git diff で `||→??` / `?? null` 追加 / 複合条件単純化のチェック (anti-pattern A/E)
- [x] live view `/uaam/result` の bulk path (`requestedAttemptId` null) parallel batch 維持で regression なし
- [x] saikaku kind では `recentIntegrationSummaries` 不在を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)