### PR TITLE
feat(admin): 統合分析タブに検索機能 + ghost-filter 防止 (#89)

### DIFF
--- a/src/screens/AdminScreen.jsx
+++ b/src/screens/AdminScreen.jsx
@@ -1216,6 +1216,11 @@ export default function AdminScreen({ user, onBack, onLogout }) {
     }
   };
 
+  const handleTabChange = (key) => {
+    setTab(key);
+    setSearch('');
+  };
+
   // 本日・今週のカウントと検索フィルター（usersやsearchが変わった時のみ再計算）
   const today = useMemo(() => {
     const todayStr = new Date().toDateString();
@@ -1269,6 +1274,18 @@ export default function AdminScreen({ user, onBack, onLogout }) {
     }
     return list;
   }, [uaamUsers, search, vFilter]);
+
+  const filteredIntegrations = useMemo(() => {
+    if (!search) return integrations;
+    const q = search.toLowerCase();
+    return integrations.filter(
+      (item) =>
+        item.userName?.toLowerCase()?.includes(q) ||
+        item.userEmail?.toLowerCase()?.includes(q) ||
+        item.source?.saikakuLabel?.toLowerCase()?.includes(q) ||
+        item.source?.uaamLabel?.toLowerCase()?.includes(q)
+    );
+  }, [integrations, search]);
 
   return (
     <div style={{ minHeight: '100vh', background: '#F5F0E8' }}>
@@ -1377,7 +1394,7 @@ export default function AdminScreen({ user, onBack, onLogout }) {
           ].map(({ key, label, count }) => (
             <button
               key={key}
-              onClick={() => setTab(key)}
+              onClick={() => handleTabChange(key)}
               style={{
                 padding: '10px 24px',
                 border: 'none',
@@ -2060,6 +2077,30 @@ export default function AdminScreen({ user, onBack, onLogout }) {
             >
               更新
             </button>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, flexWrap: 'wrap' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="名前・メール・ラベルで検索..."
+                style={{
+                  padding: '8px 14px',
+                  borderRadius: 8,
+                  border: '1px solid #D4C9B0',
+                  background: '#FDFCFA',
+                  fontSize: 13,
+                  color: '#2A2520',
+                  width: 260,
+                  fontFamily: 'Noto Sans JP, sans-serif',
+                  outline: 'none',
+                }}
+              />
+              <span style={{ textAlign: 'right', fontSize: 12, color: '#D4C9B0' }}>
+                {filteredIntegrations.length} 件表示 / 総計 {integrations.length} 件
+              </span>
+            </div>
             <button
               onClick={handleExportIntegrations}
               disabled={exporting}
@@ -2128,6 +2169,10 @@ export default function AdminScreen({ user, onBack, onLogout }) {
             <div style={{ padding: '48px', textAlign: 'center', color: '#7A7060', fontSize: 14 }}>
               まだ統合分析がありません
             </div>
+          ) : filteredIntegrations.length === 0 ? (
+            <div style={{ padding: '48px', textAlign: 'center', color: '#7A7060', fontSize: 14 }}>
+              該当する統合分析が見つかりません
+            </div>
           ) : (
             <div style={{ overflowX: 'auto' }}>
               <table aria-label="統合分析一覧" style={{ width: '100%', minWidth: 920, borderCollapse: 'collapse' }}>
@@ -2159,7 +2204,7 @@ export default function AdminScreen({ user, onBack, onLogout }) {
                   </tr>
                 </thead>
                 <tbody>
-                  {integrations.map((item, idx) => (
+                  {filteredIntegrations.map((item, idx) => (
                     <tr
                       key={`${item.uid || 'unknown'}-${item.pairKey || idx}`}
                       onClick={() => setSelectedIntegration(item)}
@@ -2223,10 +2268,6 @@ export default function AdminScreen({ user, onBack, onLogout }) {
             </div>
           )}
         </div>
-
-        <p style={{ textAlign: 'center', fontSize: 12, color: '#D4C9B0', marginTop: 16 }}>
-          {integrations.length} 件表示 / 総計 {integrations.length} 件
-        </p>
         </>)}
       </div>
 

--- a/tests/e2e/admin-integrations-search.spec.js
+++ b/tests/e2e/admin-integrations-search.spec.js
@@ -1,0 +1,227 @@
+import { test, expect } from '@playwright/test';
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import {
+  clearUser,
+  createAuthUser,
+  downloadCsvAndAssert,
+  loginAs,
+  saikakuParent,
+  seedUser,
+  uaamParent,
+} from './_helpers.js';
+import { buildPairKey } from '../../shared/integrationsKey.js';
+
+const password = 'password123';
+const adminEmail = (process.env.ADMIN_EMAILS || process.env.VITE_ADMIN_EMAILS || 'admin-e2e@example.com')
+  .split(',')
+  .map((email) => email.trim())
+  .filter(Boolean)[0];
+
+const UIDS = {
+  alpha: 'e2e-admin-integrations-search-alpha',
+  beta: 'e2e-admin-integrations-search-beta',
+  gamma: 'e2e-admin-integrations-search-gamma',
+};
+
+const ALPHA_EMAIL = 'e2e-int-search-a1@example.com';
+const BETA_EMAIL = 'e2e-int-search-b2@example.com';
+const GAMMA_EMAIL = 'e2e-int-search-c3@example.com';
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+  }
+  return getFirestore();
+}
+
+function getAdminAuth() {
+  if (!getApps().length) {
+    initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || 'demo-saikaku' });
+  }
+  return getAuth();
+}
+
+function at(day) {
+  return Timestamp.fromDate(new Date(`2026-05-${String(day).padStart(2, '0')}T00:00:00.000Z`));
+}
+
+async function deleteCollectionDocs(collectionRef) {
+  const snap = await collectionRef.get();
+  if (snap.empty) return;
+  const batch = getDb().batch();
+  snap.docs.forEach((docSnap) => batch.delete(docSnap.ref));
+  await batch.commit();
+}
+
+async function clearIntegrationDocs(uid) {
+  await deleteCollectionDocs(getDb().collection('uaam_results').doc(uid).collection('integrations'));
+}
+
+async function clearFixtureUid(uid) {
+  await clearIntegrationDocs(uid);
+  await clearUser(uid);
+}
+
+async function deleteAuthUserByEmail(email) {
+  try {
+    const user = await getAdminAuth().getUserByEmail(email);
+    await clearUser(user.uid);
+    await getAdminAuth().deleteUser(user.uid);
+  } catch (e) {
+    if (e.code !== 'auth/user-not-found') throw e;
+  }
+}
+
+async function cleanup() {
+  await Promise.all(Object.values(UIDS).map(clearFixtureUid));
+  await deleteAuthUserByEmail(adminEmail);
+}
+
+async function seedParentPair(uid, overrides = {}) {
+  await Promise.all([
+    seedUser(uid, 'saikaku', {
+      parent: {
+        ...saikakuParent(1),
+        uid,
+        name: overrides.name,
+        email: overrides.email,
+        latestAttemptId: overrides.latestSaikakuAttemptId,
+      },
+    }),
+    seedUser(uid, 'uaam', {
+      parent: {
+        ...uaamParent(1),
+        uid,
+        name: overrides.name,
+        email: overrides.email,
+        latestAttemptId: overrides.latestUaamAttemptId,
+      },
+    }),
+  ]);
+}
+
+async function seedIntegration(uid, saikakuAttemptId, uaamAttemptId, overrides = {}) {
+  const pairKey = buildPairKey(saikakuAttemptId, uaamAttemptId);
+  await getDb().collection('uaam_results').doc(uid).collection('integrations').doc(pairKey).set({
+    saikakuAttemptId,
+    uaamAttemptId,
+    integration: {
+      integration_score: overrides.score ?? 80,
+      activation_core: `${overrides.name} integration core`,
+    },
+    regenerationCount: 0,
+    model: 'claude-sonnet-4-20250514',
+    source: {
+      saikakuLabel: overrides.saikakuLabel,
+      uaamLabel: overrides.uaamLabel,
+    },
+    status: 'active',
+    createdAt: overrides.createdAt,
+    updatedAt: overrides.updatedAt ?? overrides.createdAt,
+  });
+}
+
+async function seedIntegrationsSearchFixture() {
+  await seedParentPair(UIDS.alpha, {
+    name: 'E2E Integration Search One',
+    email: ALPHA_EMAIL,
+    latestSaikakuAttemptId: 'saikaku-search-alpha',
+    latestUaamAttemptId: 'uaam-search-alpha',
+  });
+  await seedIntegration(UIDS.alpha, 'saikaku-search-alpha', 'uaam-search-alpha', {
+    name: 'alpha',
+    score: 91,
+    saikakuLabel: 'ALPHA-LABEL',
+    uaamLabel: 'Search UAAM One',
+    createdAt: at(11),
+  });
+
+  await seedParentPair(UIDS.beta, {
+    name: 'E2E Integration Search Two',
+    email: BETA_EMAIL,
+    latestSaikakuAttemptId: 'saikaku-search-beta',
+    latestUaamAttemptId: 'uaam-search-beta',
+  });
+  await seedIntegration(UIDS.beta, 'saikaku-search-beta', 'uaam-search-beta', {
+    name: 'beta',
+    score: 82,
+    saikakuLabel: 'Search Saikaku Two',
+    uaamLabel: 'BETA-LABEL',
+    createdAt: at(10),
+  });
+
+  await seedParentPair(UIDS.gamma, {
+    name: 'E2E Integration Search Three',
+    email: GAMMA_EMAIL,
+    latestSaikakuAttemptId: 'saikaku-search-gamma',
+    latestUaamAttemptId: 'uaam-search-gamma',
+  });
+  await seedIntegration(UIDS.gamma, 'saikaku-search-gamma', 'uaam-search-gamma', {
+    name: 'gamma',
+    score: 73,
+    saikakuLabel: 'Search Saikaku Three',
+    uaamLabel: 'Search UAAM Three',
+    createdAt: at(9),
+  });
+}
+
+test.beforeEach(async () => {
+  await cleanup();
+});
+
+test.afterEach(async () => {
+  await cleanup();
+});
+
+test('admin can search integrations by labels without narrowing CSV export', async ({ page }) => {
+  const admin = await createAuthUser(adminEmail, password);
+  await clearUser(admin.uid);
+  await seedIntegrationsSearchFixture();
+
+  await loginAs(page, adminEmail, password);
+  await page.goto('/admin');
+
+  await expect(page.getByRole('button', { name: '統合分析（—）' })).toBeVisible({ timeout: 15000 });
+  await page.getByRole('button', { name: /統合分析/ }).click();
+
+  await expect(page.getByRole('table', { name: '統合分析一覧' })).toBeVisible({ timeout: 15000 });
+  await expect(page.getByText(ALPHA_EMAIL)).toBeVisible();
+  await expect(page.getByText(BETA_EMAIL)).toBeVisible();
+  await expect(page.getByText(GAMMA_EMAIL)).toBeVisible();
+  await expect(page.getByText('3 件表示 / 総計 3 件')).toBeVisible();
+
+  const searchInput = page.getByPlaceholder('名前・メール・ラベルで検索...');
+
+  await searchInput.fill('ALPHA');
+  await expect(page.getByText(ALPHA_EMAIL)).toBeVisible();
+  await expect(page.getByText(BETA_EMAIL)).toHaveCount(0);
+  await expect(page.getByText(GAMMA_EMAIL)).toHaveCount(0);
+  await expect(page.getByText('1 件表示 / 総計 3 件')).toBeVisible();
+
+  const exportButton = page.getByRole('button', { name: 'CSVエクスポート' });
+  const { csvText } = await downloadCsvAndAssert(page, exportButton, 'saikaku_integrations.csv');
+  expect(csvText).toContain(ALPHA_EMAIL);
+  expect(csvText).toContain(BETA_EMAIL);
+  expect(csvText).toContain(GAMMA_EMAIL);
+
+  await searchInput.fill('BETA');
+  await expect(page.getByText(ALPHA_EMAIL)).toHaveCount(0);
+  await expect(page.getByText(BETA_EMAIL)).toBeVisible();
+  await expect(page.getByText(GAMMA_EMAIL)).toHaveCount(0);
+  await expect(page.getByText('1 件表示 / 総計 3 件')).toBeVisible();
+
+  await searchInput.fill('alpha');
+  await expect(page.getByText(ALPHA_EMAIL)).toBeVisible();
+  await expect(page.getByText(BETA_EMAIL)).toHaveCount(0);
+  await expect(page.getByText(GAMMA_EMAIL)).toHaveCount(0);
+
+  await searchInput.fill('missing-label');
+  await expect(page.getByText('該当する統合分析が見つかりません')).toBeVisible();
+  await expect(page.getByText('0 件表示 / 総計 3 件')).toBeVisible();
+
+  await searchInput.fill('ALPHA');
+  await page.getByRole('button', { name: /才覚領域/ }).click();
+  await expect(page.getByPlaceholder('名前・メール・才覚領域で検索...')).toHaveValue('');
+});


### PR DESCRIPTION
## 概要

統合分析タブに検索機能を追加し、合わせて全タブの ghost-filter 問題を解消（Issue #89）。

## 変更内容

### 検索機能
- `filteredIntegrations` useMemo を追加（`userName` / `userEmail` / `source.saikakuLabel` / `source.uaamLabel` の case-insensitive substring 一致）
- 統合分析タブヘッダーに検索 input を追加（placeholder: `"名前・メール・ラベルで検索..."`）
- 件数表示「{filteredIntegrations.length} 件表示 / 総計 {integrations.length} 件」を search input 直下に配置
- フィルタ後 0 件の場合「該当する統合分析が見つかりません」

### Ghost-filter 防止 (Round 2 Critical)
- `handleTabChange(key)` で `setTab(key)` + `setSearch('')` を一体化
- 全 3 タブ (saikaku / UAAM / integrations) の click ハンドラを `handleTabChange` に置換
- これにより saikaku → UAAM 等の切替時に旧検索文字列が引き継がれてヒット件数 0 になる潜在バグを解消

### バグ修正（オマケ）
- 旧 hardcoded `<p>{integrations.length} 件表示 / 総計 {integrations.length}</p>` を削除（同じ値を二重表示していた）

### Export 挙動の維持
- `handleExportIntegrations` は引き続き `integrations` 全件を渡す（PR-B と同じ）
- e2e で「フィルタ中でも export は 3 件全件」を assert

## テスト

- `npm run test -- exportCsv uaamExportFields integrationsExportFields` → 21 passed (regression なし)
- `npm run test:e2e -- admin-integrations-search` → 1 passed (6 シナリオカバー)
- `npm run test:e2e -- admin-integrations-export` → 1 passed (regression なし)
- `npm run build` → clean

### E2E シナリオ
1. `"ALPHA"` 検索 → ALPHA-LABEL 行のみ表示
2. `"BETA"` 検索 → BETA-LABEL 行のみ表示
3. `"alpha"` 小文字検索 → ALPHA-LABEL マッチ（case-insensitive 確認）
4. 件数表示 `"1 件表示 / 総計 3 件"` 検証
5. フィルタ中に export → CSV body 3 行（全件出力確認）
6. 才覚領域タブ切替 → saikaku 検索 input が空（ghost-filter 防止確認）

## 関連

- Issue: #89
- 順次 PR の 3/3: PR-A (#91) / PR-B (#93) はマージ済み、これが最後
- 計画: `plans/issues-87-88-89-uaam-integration-export-search.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)