### PR TITLE
docs(#87 #88 #89): 管理画面 CSV エクスポート + 検索機能を反映

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -66,6 +66,24 @@
 
 ---
 
+## 管理画面のクライアント側機能 (#87 / #88 / #89)
+
+| 機能 | 場所 | 備考 |
+|---|---|---|
+| 才覚 CSV エクスポート | `handleExport` → `/api/admin/export` | サーバー側 export (既存)。本番稼働中・自動テストなしのため変更しない |
+| **UAAM 診断 CSV エクスポート** | `handleExportUaam` + `src/utils/uaamExport.js` (#87) | **クライアント側生成**。`uaamUsers` state を allowlist で投影。追加 API なし・追加 Firestore Read なし |
+| **統合分析 CSV エクスポート** | `handleExportIntegrations` + `src/utils/integrationsExport.js` (#88) | **クライアント側生成**。`integrations` state を allowlist で投影。`coachingAnswers` / `integration.summary` / `integration.recommendations` は allowlist 不在で物理的に除外 |
+| **統合分析タブ検索** | `filteredIntegrations` useMemo (#89) | `userName` / `userEmail` / `source.saikakuLabel` / `source.uaamLabel` で case-insensitive 一致。export は filter 非適用で全件出力 |
+| 共通 CSV ビルダー | `src/utils/exportCsv.js` (#87) | allowlist 方式 `buildCsv(rows, fieldDefs)` + DOM ダウンロード `downloadCsv(filename, csvText)`。formula injection 中和 (`'` prefix) を `escapeCsvCell` で自動適用 |
+| タブ切替時の検索リセット | `handleTabChange` (#89) | 全 3 タブ (saikaku / UAAM / integrations) で `setSearch('')` を一体化、ghost-filter 防止 |
+
+**重要な不変条件**:
+- CSV ビルダーは `fieldDefs` allowlist に列挙された key のみ抽出。`...row` スプレッドや `Object.values(row)` での全フィールドダンプは禁止 (Round 2 debate critical)
+- export は常に全件 (`uaamUsers` / `integrations` の元配列を渡す)。検索フィルタ後の subset は使わない
+- `bias_message` の三状態 (`undefined` = legacy → recalc, `null` = 明示的健全, object = 保存済み) を `resolveBiasMessage` で保持。`|| null` での coercion は禁止
+
+---
+
 ## 構造的防衛層（バグ再発防止）
 
 ### ① Contract層（AIレスポンス検証）

--- a/docs/spec/integrations-schema.md
+++ b/docs/spec/integrations-schema.md
@@ -122,6 +122,45 @@ All fields are top-level fields. They are not nested under `analysis`.
 | 504 | `upstream_timeout` | LLM call exceeded 9.5min (lock window) |
 | 500 | `internal_error` | unexpected error. Body contains only `{ code, requestId }`. Stack/message logged server-side with `requestId` for correlation |
 
+## CSV Export from Admin Screen (#88)
+
+`src/utils/integrationsExport.js` provides the column allowlist consumed by `src/screens/AdminScreen.jsx` → `handleExportIntegrations`. The CSV is built **client-side** from the `/api/admin/integrations` response — no additional Firestore reads, no server-side export endpoint.
+
+### Allowlisted Columns
+
+| Column | Source | Notes |
+|---|---|---|
+| `名前` | `item.userName` | from API `userName` |
+| `メール` | `item.userEmail` | from API `userEmail` |
+| `pairKey` | `item.pairKey` | doc id, `${saikakuAttemptId}__${uaamAttemptId}` |
+| `saikakuAttemptId` | `item.saikakuAttemptId` | |
+| `uaamAttemptId` | `item.uaamAttemptId` | |
+| `saikakuLabel` | **`item.source?.saikakuLabel`** | **nested under `source`**, not top-level |
+| `uaamLabel` | **`item.source?.uaamLabel`** | **nested under `source`**, not top-level |
+| `regenerationCount` | `item.regenerationCount ?? 0` | `??` preserves falsy 0 |
+| `integration_score` | `item.integration?.integration_score ?? ''` | |
+| `status` | `item.status` | `'active'` / `'stale'` |
+| `staleSaikaku` | `item.staleSaikaku ? 'true' : 'false'` | boolean → string |
+| `staleUaam` | `item.staleUaam ? 'true' : 'false'` | boolean → string |
+| `model` | `item.model` | |
+| `isLegacyFallback` | `item.isLegacyFallback ? 'true' : 'false'` | boolean → string |
+| `createdAt` | `item.createdAt` | ISO string already from API |
+| `updatedAt` | `item.updatedAt` | ISO string already from API |
+
+### Excluded (allowlist enforcement)
+
+The following fields exist in the `/api/admin/integrations` response but are **physically absent from CSV** because they are not in `INTEGRATIONS_EXPORT_FIELD_DEFS`:
+
+- `coachingAnswers` — privacy
+- `integration.summary`, `integration.recommendations`, `integration.{any other body field}` — privacy + cell bloat
+- `_createdAtMillis` — internal sort key, irrelevant to consumers
+
+E2E leak guard: `tests/utils/integrationsExportFields.test.js` injects mock `coachingAnswers`, `integration.summary`, `integration.recommendations` and asserts those strings are absent from `buildCsv()` output. This is the contract — adding a field to the response payload does NOT add it to the CSV unless the allowlist is updated.
+
+### Sanitization
+
+- `escapeCsvCell` (in `src/utils/exportCsv.js`) prefixes any cell starting with `=` / `+` / `-` / `@` / `\t` / `\r` with `'` to neutralize spreadsheet formula injection (OWASP CSV Injection Prevention compliant).
+
 ## attemptId Validation (Phase 2 M-4)
 
 - Shared predicate `isValidAttemptId(s)` in `shared/attemptLogic.js`.

--- a/docs/spec/integrations-schema.md
+++ b/docs/spec/integrations-schema.md
@@ -153,7 +153,8 @@ The following fields exist in the `/api/admin/integrations` response but are **p
 
 - `coachingAnswers` — privacy
 - `integration.summary`, `integration.recommendations`, `integration.{any other body field}` — privacy + cell bloat
-- `_createdAtMillis` — internal sort key, irrelevant to consumers
+
+Note: `_createdAtMillis` is used server-side for sort then stripped before response (`integrations.map(({ _createdAtMillis, ...item }) => item)` in `api/admin/integrations.js`), so it never reaches the client and is irrelevant to the CSV contract.
 
 E2E leak guard: `tests/utils/integrationsExportFields.test.js` injects mock `coachingAnswers`, `integration.summary`, `integration.recommendations` and asserts those strings are absent from `buildCsv()` output. This is the contract — adding a field to the response payload does NOT add it to the CSV unless the allowlist is updated.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,10 +5,11 @@
 | 層 | コマンド | カバレッジ | 所要時間 |
 |----|----------|------------|----------|
 | Unit | `npm run test:unit` | バッジ表示ロジック / attemptAdapter / AdminScreen 統合分析タブ / UAAMResultScreen 最近の統合分析リスト (90 tests) | < 10 秒 |
+| UI | `npm test` (vitest.ui.config.js) | LoginScreen / AllPairsTriangle / coaching-answers-client / normalize-question-text + **CSV エクスポート (exportCsv / uaamExportFields / integrationsExportFields, #87 / #88)** (65 tests) | 〜3 秒 |
 | Rules | `npm run test:rules` | Firestore rules 21 シナリオ (`/api/me/*` 経由化で attempts/uaam_results parent の read deny を反転検証) | 〜2 秒 |
 | API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency + `/api/me/*` BFF + `/api/admin/integrations` (134 tests) | 〜30 秒 |
-| E2E | `npm run test:e2e` | Playwright 39 フロー (badge/history/limit/admin-integrations/uaam-recent-integrations 等) | 〜170 秒 |
-| **All** | `npm run test:all` | 全部直列実行 | 〜210 秒 |
+| E2E | `npm run test:e2e` | Playwright 16 spec ファイル (badge/history/limit/admin-integrations/uaam-recent-integrations + **admin-uaam-export (#87) / admin-integrations-export (#88) / admin-integrations-search (#89)**) | 〜180 秒 |
+| **All** | `npm run test:all` | 全部直列実行 | 〜220 秒 |
 
 ## 前提
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@
 | UI | `npm test` (vitest.ui.config.js) | LoginScreen / AllPairsTriangle / coaching-answers-client / normalize-question-text + **CSV エクスポート (exportCsv / uaamExportFields / integrationsExportFields, #87 / #88)** (65 tests) | 〜3 秒 |
 | Rules | `npm run test:rules` | Firestore rules 21 シナリオ (`/api/me/*` 経由化で attempts/uaam_results parent の read deny を反転検証) | 〜2 秒 |
 | API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency + `/api/me/*` BFF + `/api/admin/integrations` (134 tests) | 〜30 秒 |
-| E2E | `npm run test:e2e` | Playwright 16 spec ファイル (badge/history/limit/admin-integrations/uaam-recent-integrations + **admin-uaam-export (#87) / admin-integrations-export (#88) / admin-integrations-search (#89)**) | 〜180 秒 |
+| E2E | `npm run test:e2e` | Playwright 42 tests / 16 spec ファイル (badge/history/limit/admin-integrations/uaam-recent-integrations + **admin-uaam-export (#87) / admin-integrations-export (#88) / admin-integrations-search (#89)**) | 〜240 秒 |
 | **All** | `npm run test:all` | 全部直列実行 | 〜220 秒 |
 
 ## 前提

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@
 | Rules | `npm run test:rules` | Firestore rules 21 シナリオ (`/api/me/*` 経由化で attempts/uaam_results parent の read deny を反転検証) | 〜2 秒 |
 | API | `npm run test:api` | Reservation / Commit / Rollback / migration / concurrency + `/api/me/*` BFF + `/api/admin/integrations` (134 tests) | 〜30 秒 |
 | E2E | `npm run test:e2e` | Playwright 42 tests / 16 spec ファイル (badge/history/limit/admin-integrations/uaam-recent-integrations + **admin-uaam-export (#87) / admin-integrations-export (#88) / admin-integrations-search (#89)**) | 〜240 秒 |
-| **All** | `npm run test:all` | 全部直列実行 | 〜220 秒 |
+| **All** | `npm run test:all` | Unit → UI → Rules → API → E2E を直列実行 (PR #96 で UI 層を追加、CSV エクスポート regression が CI で漏れない) | 〜225 秒 |
 
 ## 前提
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:rules": "PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH firebase emulators:exec --only firestore --project demo-saikaku 'vitest run tests/rules'",
     "test:api": "PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH firebase emulators:exec --only auth,firestore --project demo-saikaku 'cross-env NODE_ENV=test MOCK_ANTHROPIC=1 TEST_BYPASS_AUTH=1 vitest run tests/api'",
     "test:e2e": "PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH node scripts/test-e2e-orchestrator.mjs",
-    "test:all": "npm run test:unit && npm run test:rules && npm run test:api && npm run test:e2e"
+    "test:all": "npm run test:unit && npm test && npm run test:rules && npm run test:api && npm run test:e2e"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",


### PR DESCRIPTION
## 概要

PR #91 / #93 / #95 マージ後の Plan Phase 3 (`sync-docs`)。3 機能をドキュメントに反映。

## 変更内容

### HANDOFF.md
- 「管理画面のクライアント側機能」セクションを新設（既存「API責務マップ」の下）
- UAAM / 統合分析 CSV エクスポート、検索機能、共通 CSV ビルダー、ghost-filter 防止を表で整理
- 不変条件（allowlist 厳守 / 全件 export / `bias_message` 三状態保持）を明記

### docs/spec/integrations-schema.md
- 「CSV Export from Admin Screen (#88)」節を追加（attemptId Validation の前）
- 16 列の allowlist フィールド一覧
- `item.source.saikakuLabel` / `item.source.uaamLabel` の入れ子構造を明示
- 物理的除外フィールド（`coachingAnswers` / `integration.summary` / `integration.recommendations` / `_createdAtMillis`）と leak guard テストの責務
- `escapeCsvCell` の formula injection neutralization (OWASP CSV Injection Prevention)

### docs/testing.md
- 4 層 → 5 層に拡張（UI 層 = `npm test` / `vitest.ui.config.js` を独立行で追加、65 tests）
- E2E 層: spec ファイル数表記に変更 + 新規 3 specs を明記
- All の所要時間を 210s → 220s に更新

## 関連

- Issue: #87 / #88 / #89（すべてマージ済み）
- 計画: `plans/issues-87-88-89-uaam-integration-export-search.md`
- 順次 PR: #91 (PR-A UAAM CSV) / #93 (PR-B 統合分析 CSV) / #95 (PR-C 検索)

🤖 Generated with [Claude Code](https://claude.com/claude-code)