### PR TITLE
feat(alpha-progress): 6/6進捗報告会 共鳴シートを別ルート/alpha-progressで新設

### DIFF
--- a/plans/alpha-progress-66.md
+++ b/plans/alpha-progress-66.md
@@ -1,0 +1,130 @@
+## Project: α進捗報告会 共鳴シート（6/6）ウェブアプリ化
+
+### 概要
+- **目的**: 6/6 RETREAT α 進捗報告会の「事業マッチング用 共鳴シート」を公開ウェブアプリ化（Drive引き継ぎ書の依頼）
+- **スコープ**: saikaku-architecture（Vite+React+Vercel+Firebase）に **別ルート `/alpha-progress`・別イベントID** で新設。既存 `/alpha`（人単位23名・本番稼働中）は**無改変**
+- **期限**: 2026-06-06 12:00（会議開始前に稼働）。最速・低リスク優先
+- **配布URL**: `https://saikaku-architecture.vercel.app/alpha-progress`
+- **debate反映**: Codex+Gemini+Claude独立の3者レビュー → fact-check 済（`debate/…/round-1/fact-check.md`）
+
+---
+
+## 前提確認 (Architecture Sanity Check)
+
+### A. 既存実装との整合性
+
+| 項目 | 内容 |
+|---|---|
+| 同種の既存ファイル | `src/alpha/AlphaApp.jsx`（認証ゲート/ルート分岐）, `src/alpha/pages/AlphaInput.jsx:112,166,170,190`（Firestore直読み/直書き＋進捗）, `src/alpha/pages/AlphaAdmin.jsx:63-85,528`（全件getDocs+CSV）, `src/alpha/uaam16.js:1`（EVENT_ID/タグ） |
+| 既存パターン | クライアントから Firestore JS SDK 直読み/直書き、認証=`useEmailAuth`+`firebase.js`、ルーティング=`main.jsx:8` `pathname.startsWith('/alpha')`＋`AlphaApp.jsx:13-14` 完全一致、admin=`VITE_ADMIN_EMAILS` |
+| 本プランの選択 | `src/alpha-progress/` に複製。同パターン踏襲。`useEmailAuth`/`firebase`/`TalkLevelSelector` を import 流用。`main.jsx` は `/alpha-progress` を**先に**判定 |
+| 整合 / 逸脱 | **整合**（既存パターン踏襲）。ただし人単位→事業単位の置換は機械コピー不可（[id:impl-3] のチェックリスト参照） |
+
+### B. 前提を疑う代替案（debate 反映）
+
+| 本プランの前提 | 代替案 | 判断 |
+|---|---|---|
+| 既存非破壊の最善手は**ファイル複製** | `eventConfig` でパラメータ化し1コード共用（Gemini推奨） | **棄却（複製採用）**。Codexも「当日の共通化は本番`/alpha`への回帰リスク増で不適切」と同意。パラメータ化は後追いリファクタ |
+| ルートは`startsWith`順序で分離 | react-router で宣言的分離（Gemini推奨） | **棄却**。既存`main.jsx`方式の大改修＝回帰リスク。順序方式で当日十分 |
+| 保存パス（EVENT_ID）分離で足りる | rules を eventId 毎の最小権限に（Gemini推奨） | **つかさ判断**。現rules `firestore.rules:19 allow read: if request.auth!=null` は全認証ユーザーが全read可（既存alphaと同一）。当日はスコープ外、後追い厳格化推奨（→ 確認事項①） |
+
+> ⚠️ **表現訂正**: 「データ完全分離」は不正確。正しくは「**保存パス（EVENT_ID）の分離**」。read 権限は既存`/alpha`と同じく認証ユーザー全員に開いている。書込みは `fromUid==auth.uid` で自分のみ。
+
+---
+
+## 既存資産（import 流用＝変更しない）
+
+| 資産 | 流用 |
+|---|---|
+| `src/hooks/useEmailAuth.js` | Google OAuth(`signInWithPopup`→`Redirect`) + メール認証 + 確認メール |
+| `src/firebase.js`（auth/db/signOutUser, singleton）| 同一インスタンス共有。新ルートからimportしても既存に副作用なし |
+| `src/alpha/components/TalkLevelSelector.jsx` | ⑥後で話したい度 1-5 |
+| `firestore.rules` の `alpha_events/{eventId}/resonance/{docId}` | ワイルドカードで新ID自動許可。**変更不要** |
+
+---
+
+## データモデル
+
+Firestore: `alpha_events/{EVENT_ID}/resonance/{fromUid}__{groupId}`（保存パスのみ既存と分離）
+
+```
+EVENT_ID = 'retreat-alpha-progress-2026-0606'
+{
+  fromUid, fromName,        // 聞き手（ログインユーザー、fromUid=auth.uid 必須＝rules create条件）
+  toUid: 'g01'..'g15',      // 事業グループID
+  toName: '<事業名>',
+  saikaku: [...],           // ①才覚（最大3、'その他:xxx'形式踏襲）
+  domains: [...],           // ②領域（複数、13項目）
+  actions: [...],           // ③この事業と…（複数、6項目）
+  help: '',                 // ④★行き詰まりに力になれること（任意）
+  oneworld: '',             // ⑤★One World活用（任意） ← 既存 condition を置換
+  talkLevel: 1..5,          // ⑥後で話したい度（必須）
+  updatedAt: serverTimestamp(),
+}
+```
+
+---
+
+## Phase 0: 準備 `[id:setup]`
+
+- [ ] [id:setup] [required] feature ブランチ作成（saikaku-architecture、main は最新=`f8ae72b` 確認済み）
+  - `git checkout -b feature/alpha-progress-66`
+  - ⚠️ working tree の `screenshots/issue-47/*.png`・`.claude/settings.local.json` は無関係。**commit時は対象ファイルのみ明示 add**（`git add -A` 禁止）
+
+## Phase 1: 実装 `depends-on: setup`
+
+> **方針**: 既存コードを Opus が完全把握済み＋複製ベース＋debateが「機械コピー不可・人単位依存の全置換が必要」と警告 → **Opus 直接実装を推奨**（Codex委任はレビュー往復で12:00に間に合わせにくく、置換漏れリスクも残る）。※最終はつかさ承認（確認事項③）
+
+- [ ] [id:impl-1] 事業データ定義 `src/alpha-progress/data.js`
+  - **Goal**: `EVENT_ID='retreat-alpha-progress-2026-0606'`、`GROUPS`（15事業: id,icon,name,presenter,members）、`SAIKAKU_TAGS`(15)、`AFFINITY_DOMAINS`(13=既存11+`公益財団`+`One World`)、`RESONANCE_ACTIONS`(6)
+  - **Constraints**: GROUPS は **Drive HTML原本を再取得しbase64機械デコードして一字一句移植**（発表者・事業名の推測転記禁止）
+  - **Success**: import して15件・タグ数が揃う
+  - **Assignee**: opus
+
+- [ ] [id:impl-2] 認証ゲート＋ルーティング `src/alpha-progress/ProgressApp.jsx` ＋ `src/main.jsx`
+  - **Goal**: `AlphaApp.jsx` を複製し、ログイン見出し「α進捗報告会 共鳴シート」、`continueUrl=${origin}/alpha-progress`、admin path=`/alpha-progress/admin` 完全一致。`main.jsx` は `path.startsWith('/alpha-progress') ? ProgressApp : path.startsWith('/alpha') ? AlphaApp : AppRouter`（**/alpha-progress を先に**）
+  - **Constraints**: **`AlphaMap` の import と `isMapPath` 分岐を削除**（map はMVP対象外＝未作成のため、残すと未解決importでビルド死／`AlphaApp.jsx:7,14,593`）。既存 `src/alpha/*` は触らない
+  - **Success**: `/alpha-progress` でログイン画面表示、`/alpha` は不変、`npm run build` 成功
+  - **Assignee**: opus
+
+- [ ] [id:impl-3] 回答フォーム `src/alpha-progress/pages/ProgressInput.jsx` ＋ `components/GroupCard.jsx`
+  - **Goal**: `AlphaInput.jsx` を複製し事業単位フォーム化。設問①才覚(max3)②領域(13)③この**事業**と…④行き詰まり力(help)⑤**One World活用**(oneworld)⑥話したい度(必須)。各事業ヘッダに「①進捗 ②行き詰まり ③今後 ④One World活用」ガイド文
+  - **⚠️ 人単位依存の全置換チェックリスト（機械コピー禁止・debate指摘）**:
+    - [ ] `PRESENTERS` → `GROUPS`、`PresenterCard` → `GroupCard`（icon+事業名+`発表：`+members+done✓）
+    - [ ] `total = PRESENTERS.length - 1` → **`total = GROUPS.length`**（自己除外`-1`撤去／`AlphaInput.jsx:190`）
+    - [ ] `nextUnsaved` の `p.uid !== current.uid` 自己除外フィルタ**撤去**（`:170`）
+    - [ ] 保存スキーマ `condition` → **`oneworld`**、保存キー `${uid}__${group.id}`、`toName=group.name`
+    - [ ] presenter info 表示（`current.name.charAt(0)` 等）を事業の icon/名称に
+  - **Success**: 15事業選択→①〜⑥入力→保存で `saved.size` 増、15件で進捗15/15・完了表示
+  - **Assignee**: opus
+
+- [ ] [id:impl-4] 集計画面 `src/alpha-progress/pages/ProgressAdmin.jsx`
+  - **Goal**: `AlphaAdmin.jsx` を複製、`EVENT_ID` 差替、`/alpha-progress/admin` で表示。CSV列（Drive準拠）= 聞き手/事業/発表者/後で話したい度/才覚/領域/この事業と/力になれること/**One World活用**/記録時刻。DL名 `alpha-progress-resonance.csv`、UTF-8 BOM
+  - **Constraints**: `condition`参照を`oneworld`に、`toName`は事業名。map関連UI/importは持ち込まない
+  - **Success**: 保存済みデータが一覧表示、CSV列が要件通り
+  - **Assignee**: opus
+
+## Phase 2: 検証 `depends-on: impl-4`
+
+- [ ] [id:build] [required] `npm run build` 成功（ProgressApp static import / map除去のビルド確認＝Codex X2・Claude C3b）
+- [ ] [id:e2e-local] [required] ローカル E2E（`npm run dev:local` = Firebase emulator+api+web）
+  - `/alpha-progress` ログイン → 事業選択 → ①〜⑥入力 → 保存 → emulator Firestore に `alpha_events/retreat-alpha-progress-2026-0606/resonance/{uid}__g0x}` 生成 → 進捗カウント正常（**15/15で100%**）→ `/alpha-progress/admin` 一覧 → CSV列確認
+  - 既存 `/alpha` も起動して**無改変・無干渉**を目視
+- [ ] [id:verify-deploy] [required] preview/本番 検証 `depends-on: e2e-local`
+  - feature ブランチ push → Vercel preview。**preview では Google ログインで1事業通す**（メール認証は continueUrl allowlist 不一致リスク＝Claude C2／`send-verification-email.js:14-16`）
+  - メール認証フローの最終確認は **本番 production URL（`saikaku-architecture.vercel.app`＝ALLOWED_ORIGINS済）** で実施（main マージ後）
+  - `VITE_ADMIN_EMAILS` が Vercel 本番 env に設定済みか確認（未設定だと admin が Unauthorized／Claude C3a・確認事項②）
+- [ ] [id:opus-review] [required] Opus 差分レビュー（既存 `src/alpha/*` の diff が空＝無改変であること、`git diff --stat` で `main.jsx` 以外の既存ファイルが変わっていないこと）
+- [ ] [id:merge] main マージ → 本番デプロイ → `…/alpha-progress` 稼働確認 `depends-on: opus-review`
+
+---
+
+## つかさへの確認事項
+
+1. **rules 厳格化**: 現状 read は全認証ユーザーに開放（既存alpha同一）。内部30名・全員同意なので当日は許容予定。「他参加者の回答が技術的にread可能」を当日中に塞ぐ必要があるか？（後追い推奨だが判断を仰ぐ）
+2. **admin メール**: `VITE_ADMIN_EMAILS` に集計画面を見る人（つかさ／玄氣さん？）のメールが本番 Vercel env に入っているか
+3. **実装担当**: Opus 直接実装（推奨・最速）で進めてよいか（SKILLデフォルトは Codex 委任）
+
+## スコープ外（後追い可）
+
+- 共鳴マップ（事業×聞き手の二部グラフ）/ コードのパラメータ化（複製解消）/ rules 最小権限化 / 本番カスタムドメイン化 / Drive HTML自体の更新（モックは破棄、正本はこのアプリ）

--- a/src/alpha-progress/ProgressApp.jsx
+++ b/src/alpha-progress/ProgressApp.jsx
@@ -1,0 +1,603 @@
+import { useState, useEffect } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth, signOutUser } from '../firebase';
+import { useEmailAuth } from '../hooks/useEmailAuth';
+import { EVENT_TITLE } from './data';
+import ProgressInput from './pages/ProgressInput';
+import ProgressAdmin from './pages/ProgressAdmin';
+
+const ADMIN_EMAILS = (import.meta.env.VITE_ADMIN_EMAILS || '')
+  .split(',').map(e => e.trim()).filter(Boolean);
+
+const pathname = window.location.pathname;
+const isAdminPath = pathname === '/alpha-progress/admin';
+
+const T = {
+  bg: '#F5F0E8',
+  card: '#FFFFFF',
+  border: '#E0D8CE',
+  text: '#2A2520',
+  muted: '#8A7A6A',
+  accent: '#C4922A',
+  fontFamily: "'Noto Serif JP', 'Hiragino Sans', sans-serif",
+};
+
+function Spinner() {
+  return (
+    <div style={{
+      minHeight: '100vh', background: T.bg,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+    }}>
+      <div style={{
+        width: 36, height: 36, borderRadius: '50%',
+        border: `3px solid ${T.border}`, borderTopColor: T.accent,
+        animation: 'spin 1s linear infinite',
+      }} />
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}
+
+function ProgressLogin({ onLogin }) {
+  const {
+    state: {
+      agreed,
+      loading,
+      error,
+      authMode,
+      emailMode,
+      email,
+      password,
+      passwordConfirm,
+      displayName,
+      verificationSent,
+      fromEmail,
+      resendLoading,
+      resendMsg,
+      resendCooldown,
+    },
+    handlers: {
+      setAgreed,
+      setError,
+      setAuthMode,
+      setEmailMode,
+      setEmail,
+      setPassword,
+      setPasswordConfirm,
+      setDisplayName,
+      setVerificationSent,
+      handleLogin: handleGoogleLogin,
+      handleEmailAuth,
+      handleResendVerification,
+    },
+  } = useEmailAuth({
+    onLogin,
+    continueUrl: `${window.location.origin}/alpha-progress`,
+  });
+
+  const disabled = !agreed || loading;
+  const inputStyle = {
+    width: '100%',
+    padding: '12px 13px',
+    borderRadius: 8,
+    boxSizing: 'border-box',
+    border: `1px solid ${T.border}`,
+    background: '#FFFDF9',
+    color: T.text,
+    fontSize: 14,
+    outline: 'none',
+    fontFamily: T.fontFamily,
+  };
+  const mutedButtonStyle = {
+    width: '100%',
+    padding: '13px 16px',
+    borderRadius: 8,
+    border: `1px solid ${T.border}`,
+    background: '#FFFDF9',
+    color: T.text,
+    fontSize: 14,
+    fontWeight: 700,
+    cursor: 'pointer',
+    fontFamily: T.fontFamily,
+  };
+  const primaryButtonStyle = {
+    width: '100%',
+    padding: '14px 18px',
+    background: disabled ? T.border : T.accent,
+    color: disabled ? T.muted : '#fff',
+    border: 'none',
+    borderRadius: 8,
+    fontSize: 15,
+    fontWeight: 700,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    transition: 'background 0.2s, opacity 0.2s',
+    fontFamily: T.fontFamily,
+  };
+
+  const selectAuthMode = mode => {
+    setAuthMode(mode);
+    setError('');
+  };
+
+  const selectEmailMode = mode => {
+    setAuthMode('email');
+    setEmailMode(mode);
+    setError('');
+    setPasswordConfirm('');
+  };
+
+  const handleEmailSubmit = e => {
+    e.preventDefault();
+    handleEmailAuth();
+  };
+
+  if (verificationSent) {
+    return (
+      <div style={{
+        minHeight: '100vh',
+        background: T.bg,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px 16px',
+        fontFamily: T.fontFamily,
+      }}>
+        <style>{`
+          @keyframes spin { to { transform: rotate(360deg); } }
+          .alpha-login-input::placeholder { color: ${T.muted}; opacity: 0.72; }
+        `}</style>
+        <div style={{
+          width: '100%',
+          maxWidth: 440,
+          background: T.card,
+          border: `1px solid ${T.border}`,
+          borderRadius: 8,
+          padding: '34px 28px',
+          textAlign: 'center',
+          boxShadow: '0 10px 34px rgba(42,37,32,0.08)',
+        }}>
+          <div style={{
+            width: 52,
+            height: 52,
+            borderRadius: '50%',
+            margin: '0 auto 18px',
+            border: `1px solid ${T.accent}`,
+            color: T.accent,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <svg width="25" height="20" viewBox="0 0 25 20" fill="none" aria-hidden="true">
+              <path d="M2.5 2.5h20v15h-20v-15z" stroke="currentColor" strokeWidth="1.8" />
+              <path d="M3 3l9.5 8L22 3" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </div>
+
+          <h1 style={{
+            color: T.text,
+            fontSize: 22,
+            fontWeight: 700,
+            lineHeight: 1.45,
+            margin: '0 0 10px',
+          }}>
+            確認メールを送信しました
+          </h1>
+          <p style={{ fontSize: 14, color: T.muted, lineHeight: 1.9, margin: '0 0 20px' }}>
+            <span style={{ color: T.accent, fontWeight: 700 }}>{email}</span><br />
+            に確認メールを送りました。リンクをクリックしてから、ログイン画面に戻ってください。
+          </p>
+
+          <div style={{
+            background: '#FFF8EA',
+            border: `1px solid ${T.border}`,
+            borderRadius: 8,
+            padding: '14px 16px',
+            marginBottom: 18,
+            textAlign: 'left',
+          }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: T.text, marginBottom: 8 }}>
+              メールが見つからない場合
+            </div>
+            <ul style={{ margin: 0, padding: '0 0 0 18px', fontSize: 12, color: T.muted, lineHeight: 1.9 }}>
+              <li>迷惑メール・スパムフォルダをご確認ください</li>
+              <li>送信元：<code style={{ color: T.accent, fontSize: 11 }}>{fromEmail || 'noreply@saikaku-architecture.firebaseapp.com'}</code></li>
+              <li>件名：「メールアドレスを確認」</li>
+              <li>届くまで数分かかる場合があります</li>
+            </ul>
+          </div>
+
+          {resendMsg && (
+            <div style={{
+              marginBottom: 14,
+              padding: '10px 14px',
+              borderRadius: 8,
+              background: resendMsg.startsWith('✅') ? 'rgba(34,197,94,0.08)' : 'rgba(168,68,50,0.08)',
+              border: `1px solid ${resendMsg.startsWith('✅') ? 'rgba(34,197,94,0.22)' : 'rgba(168,68,50,0.22)'}`,
+              fontSize: 12,
+              color: resendMsg.startsWith('✅') ? '#2F855A' : '#a84432',
+              lineHeight: 1.6,
+            }}>
+              {resendMsg}
+            </div>
+          )}
+
+          <button
+            onClick={handleResendVerification}
+            disabled={resendLoading || resendCooldown > 0}
+            style={{
+              ...mutedButtonStyle,
+              marginBottom: 10,
+              color: (resendLoading || resendCooldown > 0) ? T.muted : T.text,
+              cursor: (resendLoading || resendCooldown > 0) ? 'not-allowed' : 'pointer',
+              opacity: (resendLoading || resendCooldown > 0) ? 0.65 : 1,
+            }}
+          >
+            {resendLoading ? '送信中...' : resendCooldown > 0 ? `再送信可能まで ${resendCooldown}秒` : '確認メールを再送信'}
+          </button>
+
+          <button
+            onClick={() => {
+              setVerificationSent(false);
+              setEmailMode('login');
+              setAuthMode('email');
+              setPassword('');
+              setPasswordConfirm('');
+            }}
+            style={{ ...primaryButtonStyle, color: '#fff', background: T.accent, cursor: 'pointer' }}
+          >
+            ログイン画面に戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: T.bg,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '24px 16px',
+      fontFamily: T.fontFamily,
+    }}>
+      <style>{`
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .alpha-login-input::placeholder { color: ${T.muted}; opacity: 0.72; }
+      `}</style>
+      <div style={{
+        background: T.card,
+        border: `1px solid ${T.border}`,
+        borderRadius: 8,
+        padding: '34px 28px',
+        width: '100%',
+        maxWidth: 440,
+        boxSizing: 'border-box',
+        boxShadow: '0 10px 34px rgba(42,37,32,0.08)',
+      }}>
+        <div style={{
+          textAlign: 'center',
+          marginBottom: 24,
+        }}>
+          <div style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: T.accent,
+            marginBottom: 12,
+          }}>
+            Retreat α 2026 ・ 進捗報告会 6/6
+          </div>
+          <div style={{ fontSize: 23, fontWeight: 700, color: T.text, lineHeight: 1.4, marginBottom: 6 }}>
+            {EVENT_TITLE}
+          </div>
+          <div style={{ fontSize: 13, color: T.muted, lineHeight: 1.7 }}>
+            Google またはメールアドレスでログイン
+          </div>
+        </div>
+
+        <label style={{
+          display: 'flex',
+          gap: 12,
+          alignItems: 'flex-start',
+          cursor: 'pointer',
+          marginBottom: 18,
+          padding: '13px 14px',
+          borderRadius: 8,
+          background: agreed ? '#FFF8EA' : '#FFFDF9',
+          border: `1px solid ${agreed ? 'rgba(196,146,42,0.42)' : T.border}`,
+          transition: 'all 0.2s ease',
+        }}>
+          <span style={{ position: 'relative', marginTop: 1, flexShrink: 0 }}>
+            <input
+              type="checkbox"
+              checked={agreed}
+              onChange={e => setAgreed(e.target.checked)}
+              style={{ position: 'absolute', opacity: 0, width: 20, height: 20, cursor: 'pointer' }}
+            />
+            <span style={{
+              width: 20,
+              height: 20,
+              borderRadius: 6,
+              border: `2px solid ${agreed ? T.accent : T.border}`,
+              background: agreed ? T.accent : '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              boxSizing: 'border-box',
+            }}>
+              {agreed && (
+                <svg width="11" height="9" viewBox="0 0 11 9" fill="none" aria-hidden="true">
+                  <path d="M1 4.5L4 7.5L10 1" stroke="#FFFFFF" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )}
+            </span>
+          </span>
+          <span style={{ fontSize: 12, color: T.muted, lineHeight: 1.8 }}>
+            入力情報および解析結果が<span style={{ color: T.text, fontWeight: 700 }}>主催者に共有される</span>ことに同意します
+          </span>
+        </label>
+
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 8,
+          marginBottom: 18,
+        }}>
+          {[
+            { mode: 'google', label: 'Google' },
+            { mode: 'email', label: 'メール' },
+          ].map(item => (
+            <button
+              key={item.mode}
+              type="button"
+              onClick={() => selectAuthMode(item.mode)}
+              style={{
+                padding: '9px 10px',
+                borderRadius: 8,
+                border: authMode === item.mode ? `1px solid ${T.accent}` : `1px solid ${T.border}`,
+                background: authMode === item.mode ? '#FFF8EA' : '#FFFDF9',
+                color: authMode === item.mode ? T.text : T.muted,
+                fontSize: 13,
+                fontWeight: 700,
+                cursor: 'pointer',
+                fontFamily: T.fontFamily,
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div style={{
+            fontSize: 13,
+            color: '#a84432',
+            marginBottom: 16,
+            background: '#a8443210',
+            padding: '10px 14px',
+            borderRadius: 8,
+            border: '1px solid #a8443220',
+            lineHeight: 1.6,
+            textAlign: 'center',
+          }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{
+          border: `1px solid ${authMode === 'google' ? 'rgba(196,146,42,0.38)' : T.border}`,
+          borderRadius: 8,
+          padding: 16,
+          marginBottom: 14,
+          background: authMode === 'google' ? '#FFF8EA' : '#FFFDF9',
+        }}>
+          <button
+            onClick={() => {
+              selectAuthMode('google');
+              handleGoogleLogin();
+            }}
+            disabled={disabled}
+            style={primaryButtonStyle}
+          >
+            {loading && authMode === 'google' ? (
+              <div style={{
+                width: 20,
+                height: 20,
+                borderRadius: '50%',
+                border: '2px solid rgba(255,255,255,0.35)',
+                borderTopColor: '#fff',
+                animation: 'spin 1s linear infinite',
+              }} />
+            ) : (
+              <>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
+                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                </svg>
+                Googleでログイン
+              </>
+            )}
+          </button>
+        </div>
+
+        <form
+          onSubmit={handleEmailSubmit}
+          style={{
+            border: `1px solid ${authMode === 'email' ? 'rgba(196,146,42,0.38)' : T.border}`,
+            borderRadius: 8,
+            padding: 16,
+            background: authMode === 'email' ? '#FFF8EA' : '#FFFDF9',
+          }}
+        >
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 12 }}>
+            {[
+              { mode: 'login', label: 'ログイン' },
+              { mode: 'signup', label: '新規登録' },
+            ].map(item => (
+              <button
+                key={item.mode}
+                type="button"
+                onClick={() => selectEmailMode(item.mode)}
+                style={{
+                  padding: '8px 10px',
+                  borderRadius: 8,
+                  border: emailMode === item.mode ? `1px solid ${T.accent}` : `1px solid ${T.border}`,
+                  background: emailMode === item.mode ? T.card : '#F8F3EA',
+                  color: emailMode === item.mode ? T.text : T.muted,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: 'pointer',
+                  fontFamily: T.fontFamily,
+                }}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {emailMode === 'signup' && (
+              <input
+                className="alpha-login-input"
+                type="text"
+                placeholder="お名前（表示名）"
+                value={displayName}
+                onFocus={() => selectAuthMode('email')}
+                onChange={e => setDisplayName(e.target.value)}
+                style={inputStyle}
+              />
+            )}
+            <input
+              className="alpha-login-input"
+              type="email"
+              placeholder="メールアドレス"
+              value={email}
+              onFocus={() => selectAuthMode('email')}
+              onChange={e => setEmail(e.target.value)}
+              style={inputStyle}
+            />
+            <input
+              className="alpha-login-input"
+              type="password"
+              placeholder="パスワード（6文字以上）"
+              value={password}
+              onFocus={() => selectAuthMode('email')}
+              onChange={e => setPassword(e.target.value)}
+              style={inputStyle}
+            />
+            {emailMode === 'signup' && (
+              <>
+                <input
+                  className="alpha-login-input"
+                  type="password"
+                  placeholder="パスワード（確認のため再入力）"
+                  value={passwordConfirm}
+                  onFocus={() => selectAuthMode('email')}
+                  onChange={e => setPasswordConfirm(e.target.value)}
+                  style={{
+                    ...inputStyle,
+                    border: passwordConfirm && password !== passwordConfirm
+                      ? '1px solid rgba(168,68,50,0.52)'
+                      : inputStyle.border,
+                  }}
+                />
+                {passwordConfirm && password !== passwordConfirm && (
+                  <div style={{ fontSize: 11, color: '#a84432', marginTop: -4, paddingLeft: 2 }}>
+                    パスワードが一致しません
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={disabled}
+            onClick={() => selectAuthMode('email')}
+            style={{ ...primaryButtonStyle, marginTop: 14 }}
+          >
+            {loading && authMode === 'email' ? (
+              <>
+                <div style={{
+                  width: 18,
+                  height: 18,
+                  borderRadius: '50%',
+                  border: '2px solid rgba(255,255,255,0.35)',
+                  borderTopColor: '#fff',
+                  animation: 'spin 1s linear infinite',
+                }} />
+                <span>処理中...</span>
+              </>
+            ) : (
+              emailMode === 'signup' ? '新規登録' : 'ログイン'
+            )}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Unauthorized() {
+  return (
+    <div style={{
+      minHeight: '100vh', background: T.bg,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      color: T.muted, fontFamily: T.fontFamily,
+    }}>
+      <div style={{ textAlign: 'center' }}>
+        <div style={{ fontSize: 32, marginBottom: 12 }}>🔒</div>
+        <div style={{ color: T.text }}>この画面へのアクセス権限がありません</div>
+        <a href="/alpha-progress" style={{ color: T.accent, marginTop: 16, display: 'block', fontSize: 13 }}>
+          入力画面へ戻る
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default function ProgressApp() {
+  const [user, setUser] = useState(null);
+  const [authLoading, setAuthLoading] = useState(true);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, u => {
+      setAuthLoading(false);
+      if (u) {
+        // メール認証ユーザーはメールアドレス確認が必要
+        const isEmailProvider = u.providerData.some(p => p.providerId === 'password');
+        if (isEmailProvider && !u.emailVerified) {
+          // 未確認ユーザーはログイン画面に留める（サインアウトしない）
+          setUser(null);
+          return;
+        }
+        setUser(u);
+      } else {
+        setUser(null);
+      }
+    });
+  }, []);
+
+  const handleLogout = () => {
+    signOutUser().then(() => setUser(null));
+  };
+
+  if (authLoading) return <Spinner />;
+  if (!user) return <ProgressLogin onLogin={setUser} />;
+
+  const isAdmin = ADMIN_EMAILS.includes(user.email);
+
+  if (isAdminPath) {
+    if (!isAdmin) return <Unauthorized />;
+    return <ProgressAdmin user={user} onLogout={handleLogout} />;
+  }
+
+  return <ProgressInput user={user} onLogout={handleLogout} />;
+}

--- a/src/alpha-progress/components/GroupCard.jsx
+++ b/src/alpha-progress/components/GroupCard.jsx
@@ -1,0 +1,49 @@
+// 事業グループカード（src/alpha/components/PresenterCard.jsx の事業単位版）
+export default function GroupCard({ group, done, active, onClick }) {
+  const members = group.members && group.members.length ? group.members.join('・') : '—';
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        background: active ? 'rgba(196,146,42,0.06)' : '#FFFFFF',
+        border: `1.5px solid ${active ? '#C4922A' : done ? '#2D7A4A' : '#E0D8CE'}`,
+        borderRadius: 14,
+        padding: '14px 14px 12px',
+        cursor: 'pointer',
+        position: 'relative',
+        transition: 'all 0.15s',
+        boxShadow: '0 1px 4px rgba(0,0,0,0.04)',
+        display: 'flex',
+        gap: 12,
+        alignItems: 'flex-start',
+      }}
+    >
+      {done && (
+        <span style={{
+          position: 'absolute', top: 8, right: 10,
+          fontSize: 10, fontWeight: 700, color: '#1a7a3a',
+          background: '#eef8f1', border: '1px solid #b8ddc2',
+          borderRadius: 6, padding: '2px 7px',
+        }}>✓ 回答済</span>
+      )}
+      <div style={{
+        width: 44, height: 44, flex: 'none', borderRadius: '50%',
+        background: '#EFE7D2', display: 'flex', alignItems: 'center',
+        justifyContent: 'center', fontSize: 19, fontWeight: 800, color: '#9C7D18',
+      }}>
+        {group.icon}
+      </div>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: 14.5, fontWeight: 800, color: '#2A2520', lineHeight: 1.35 }}>
+          {group.name}
+        </div>
+        <div style={{ fontSize: 11.5, color: '#9C7D18', marginTop: 5, fontWeight: 700 }}>
+          発表：{group.presenter}
+        </div>
+        <div style={{ fontSize: 11, color: '#8A7A6A', marginTop: 3, lineHeight: 1.4 }}>
+          {members}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/alpha-progress/data.js
+++ b/src/alpha-progress/data.js
@@ -1,0 +1,52 @@
+// α進捗報告会 共鳴シート（6/6）データ定義
+// 出典: Drive「回答フォーム（html)」/ α進捗報告会_共鳴シート_v1.0.html の GROUPS 定数（base64原本をデコードして移植）
+// 既存 src/alpha/uaam16.js（人単位23名）とは別物。こちらは事業単位15グループ。
+
+export const EVENT_ID = 'retreat-alpha-progress-2026-0606';
+
+export const EVENT_TITLE = 'α進捗報告会 共鳴シート';
+export const EVENT_SUBTITLE = 'RETREAT α 2026 ・ 進捗報告会 6/6';
+
+// 15 事業グループ（id, icon, name, presenter, members）
+// 各事業は「①進捗 / ②行き詰まり / ③今後 / ④One World活用」を発表する
+export const GROUPS = [
+  { id: 'g01', icon: '祈', name: '日常生活に祈りを取り戻すAI大和風水プロジェクト', presenter: '長田広美', members: ['林司', '小嶋勇治', '野田健一', '勝屋裕貴'] },
+  { id: 'g02', icon: '學', name: '学童保育プロジェクト', presenter: '飯塚玄氣・長田広美', members: ['宇田川昌美（欠席）'] },
+  { id: 'g03', icon: '🍯', name: 'はちみつプロジェクト', presenter: '杉永竜之助', members: ['鈴木栄子', 'haru', '奈都'] },
+  { id: 'g04', icon: '⭐️', name: 'クラファンプロジェクト', presenter: '山永彩葵', members: ['杉永竜之助', '飯塚玄氣', '小嶋勇治'] },
+  { id: 'g05', icon: '虹', name: 'LGBTの次の時代のロールモデル創出プロジェクト（仮）', presenter: '坂口友亮', members: [] },
+  { id: 'g06', icon: '香', name: 'バーム開発', presenter: '細川さゆり', members: ['奈都'] },
+  { id: 'g07', icon: '保', name: '保険募集人から日本を大丈夫に', presenter: '原田祐介', members: ['道又正人'] },
+  { id: 'g08', icon: 'AI', name: '業界リーディングカンパニーのAIトランスフォーメーション', presenter: '藤原宗賢', members: ['塚原厚'] },
+  { id: 'g09', icon: '祭', name: 'アーティスト祭（仮）', presenter: '浜口奈々', members: [] },
+  { id: 'g10', icon: '♪', name: 'ハミングプロジェクト', presenter: '根木マリサ', members: [] },
+  { id: 'g11', icon: '寺', name: '全国の無縁仏を解消しお寺の保全へ 墓地環境保全事業部', presenter: '遠山直樹', members: ['奈都', '石井裕二'] },
+  { id: 'g12', icon: '司', name: '国作り事業をサポートする作戦司令部設立及び新会社設立', presenter: '遠山直樹', members: ['奈都', 'haru'] },
+  { id: 'g13', icon: '腸', name: '腸活健康イノベーション', presenter: '根本輝尚', members: ['奈都', 'haru', '藤田明日香（補佐）', '岩田和真（補佐）'] },
+  { id: 'g14', icon: '雅', name: '神社交界・雅の会', presenter: '藤田由美子', members: ['奈都'] },
+  { id: 'g15', icon: '麻', name: '神社、ヘンププロジェクト', presenter: '島田知幸（発表・動画）', members: ['奈都'] },
+];
+
+// ① この事業に感じた才覚（最大3）
+export const SAIKAKU_TAGS = [
+  'ストーリー力', '人を巻き込む力', '分析力', '実行力', '調和力',
+  '発信力', '営業力', '共感力', '企画力', '教育力',
+  '専門性', '世界観', '熱量', '信頼感', 'その他',
+];
+
+// ② 響いた／可能性を感じた領域（複数可）。Drive原本準拠で13項目（公益財団・One World を含む）
+export const AFFINITY_DOMAINS = [
+  'AI', '教育', '地域活性', '芸術・表現', 'チームビルディング',
+  'コミュニティ', '経営', '福祉', '国際', 'SNS',
+  '公益財団', 'One World', 'その他',
+];
+
+// ③ この事業と…（複数可）
+export const RESONANCE_ACTIONS = [
+  '一緒に何かやりたい',
+  '応援したい',
+  '詳しく話したい',
+  '紹介したい人がいる',
+  '自分が手伝えることがある',
+  '今後可能性を感じる',
+];

--- a/src/alpha-progress/pages/ProgressAdmin.jsx
+++ b/src/alpha-progress/pages/ProgressAdmin.jsx
@@ -1,0 +1,191 @@
+import { useState, useEffect } from 'react';
+import { getDocs, collection } from 'firebase/firestore';
+import { db } from '../../firebase';
+import { GROUPS, EVENT_ID, EVENT_TITLE } from '../data';
+
+const T = {
+  bg: '#F5F0E8', card: '#FFFFFF', border: '#E0D8CE', borderSubtle: '#EDE8E0',
+  text: '#2A2520', muted: '#8A7A6A', sub: '#6A5A4A', accent: '#C4922A',
+  accentBg: 'rgba(196,146,42,0.10)',
+  fontFamily: "'Noto Serif JP', 'Hiragino Sans', sans-serif",
+};
+
+// ── CSV書き出し（Drive README の列定義に準拠） ──
+function exportCSV(resonances) {
+  const headers = [
+    '聞き手', '事業', '発表者', '後で話したい度',
+    '才覚', '領域', 'この事業と', '力になれること', 'One World活用', '記録時刻',
+  ];
+  const groupName = id => GROUPS.find(g => g.id === id);
+  const rows = resonances.map(r => {
+    const g = groupName(r.toUid);
+    return [
+      r.fromName || r.fromUid?.slice(0, 8) || '',
+      r.toName || (g && g.name) || r.toUid,
+      r.presenter || (g && g.presenter) || '',
+      r.talkLevel ?? '',
+      (r.saikaku ?? []).join('|'),
+      (r.domains ?? []).join('|'),
+      (r.actions ?? []).join('|'),
+      (r.help ?? '').replace(/\n/g, ' '),
+      (r.oneworld ?? '').replace(/\n/g, ' '),
+      formatTs(r.updatedAt),
+    ];
+  });
+  const csv = [headers, ...rows]
+    .map(row => row.map(cell => `"${String(cell ?? '').replace(/"/g, '""')}"`).join(','))
+    .join('\r\n');
+  const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'alpha-progress-resonance.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function formatTs(ts) {
+  if (!ts) return '';
+  try {
+    const d = ts.toDate ? ts.toDate() : new Date(ts);
+    return d.toLocaleString('ja-JP');
+  } catch { return ''; }
+}
+
+function Avatar({ icon }) {
+  return (
+    <div style={{
+      width: 40, height: 40, borderRadius: '50%', flexShrink: 0,
+      background: '#EFE7D2', display: 'flex', alignItems: 'center',
+      justifyContent: 'center', fontSize: 18, fontWeight: 800, color: '#9C7D18',
+    }}>{icon}</div>
+  );
+}
+
+function Tag({ children, color }) {
+  return (
+    <span style={{
+      fontSize: 11, padding: '2px 8px', borderRadius: 4,
+      background: `${color}1A`, color, fontWeight: 600,
+    }}>{children}</span>
+  );
+}
+
+export default function ProgressAdmin({ user, onLogout }) {
+  const [resonances, setResonances] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const snap = await getDocs(collection(db, 'alpha_events', EVENT_ID, 'resonance'));
+        setResonances(snap.docs.map(d => d.data()));
+      } catch (e) {
+        console.warn('[ProgressAdmin] load error:', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const respondents = new Set(resonances.map(r => r.fromUid)).size;
+
+  return (
+    <div style={{
+      maxWidth: 920, margin: '0 auto', minHeight: '100vh', padding: 16,
+      background: T.bg, color: T.text, fontFamily: T.fontFamily,
+    }}>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '12px 4px 16px', borderBottom: `1px solid ${T.border}`, marginBottom: 20, flexWrap: 'wrap', gap: 10,
+      }}>
+        <div>
+          <div style={{ fontSize: 18, fontWeight: 700 }}>{EVENT_TITLE}　集計</div>
+          <div style={{ fontSize: 11, color: T.accent, letterSpacing: '0.12em', marginTop: 2 }}>
+            回答 {resonances.length} 件 ・ 回答者 {respondents} 名
+          </div>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <button onClick={() => exportCSV(resonances)} disabled={!resonances.length} style={{
+            background: resonances.length ? T.accent : T.border, color: '#fff', border: 'none',
+            fontSize: 13, fontWeight: 700, padding: '8px 16px', borderRadius: 8,
+            cursor: resonances.length ? 'pointer' : 'not-allowed',
+          }}>CSV出力</button>
+          <button onClick={onLogout} style={{
+            background: 'transparent', border: `1px solid ${T.border}`, color: T.muted,
+            fontSize: 11, padding: '6px 12px', borderRadius: 6, cursor: 'pointer',
+          }}>ログアウト</button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: 60 }}>
+          <div style={{
+            width: 36, height: 36, borderRadius: '50%',
+            border: `3px solid ${T.border}`, borderTopColor: T.accent,
+            animation: 'spin 1s linear infinite',
+          }} />
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          {GROUPS.map(g => {
+            const entries = resonances
+              .filter(r => r.toUid === g.id)
+              .sort((a, b) => (b.talkLevel || 0) - (a.talkLevel || 0));
+            const avg = entries.length
+              ? (entries.reduce((s, r) => s + (r.talkLevel || 0), 0) / entries.length).toFixed(1)
+              : '—';
+            return (
+              <div key={g.id} style={{
+                background: T.card, border: `1px solid ${T.border}`, borderRadius: 12, padding: 16,
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
+                  <Avatar icon={g.icon} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 15, fontWeight: 800 }}>{g.name}</div>
+                    <div style={{ fontSize: 11.5, color: T.accent, marginTop: 2, fontWeight: 700 }}>発表：{g.presenter}</div>
+                  </div>
+                  <div style={{ fontSize: 12, color: T.muted, textAlign: 'right' }}>
+                    {entries.length} 件<br />
+                    <span style={{ fontSize: 11 }}>平均 {avg}</span>
+                  </div>
+                </div>
+
+                {entries.length === 0 ? (
+                  <div style={{ fontSize: 12, color: T.muted, padding: '8px 0' }}>まだ回答がありません</div>
+                ) : (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                    {entries.map((r, i) => (
+                      <div key={i} style={{
+                        borderTop: `1px solid ${T.borderSubtle}`, paddingTop: 10,
+                      }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                          <span style={{ fontSize: 13, fontWeight: 700 }}>{r.fromName || '—'}</span>
+                          <span style={{
+                            fontSize: 11, background: T.accentBg, color: T.accent,
+                            padding: '2px 8px', borderRadius: 4, fontWeight: 700,
+                          }}>後で話したい度 {r.talkLevel}</span>
+                          {(r.saikaku ?? []).map((s, j) => <Tag key={`s${j}`} color="#6B5A9A">{s}</Tag>)}
+                          {(r.actions ?? []).map((s, j) => <Tag key={`a${j}`} color="#2D7A4A">{s}</Tag>)}
+                        </div>
+                        {(r.domains ?? []).length > 0 && (
+                          <div style={{ fontSize: 11, color: T.muted, marginTop: 4 }}>領域: {(r.domains ?? []).join('・')}</div>
+                        )}
+                        {r.help && <div style={{ fontSize: 12, color: T.sub, marginTop: 4 }}>★力になれること: {r.help}</div>}
+                        {r.oneworld && <div style={{ fontSize: 12, color: T.sub, marginTop: 2 }}>★One World活用: {r.oneworld}</div>}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/alpha-progress/pages/ProgressInput.jsx
+++ b/src/alpha-progress/pages/ProgressInput.jsx
@@ -1,0 +1,456 @@
+import { useState, useEffect, useRef } from 'react';
+import { doc, setDoc, getDocs, collection, serverTimestamp } from 'firebase/firestore';
+import { db } from '../../firebase';
+import { GROUPS, EVENT_ID, EVENT_TITLE, SAIKAKU_TAGS, AFFINITY_DOMAINS, RESONANCE_ACTIONS } from '../data';
+import GroupCard from '../components/GroupCard';
+import TalkLevelSelector from '../../alpha/components/TalkLevelSelector';
+
+const T = {
+  bg: '#F5F0E8',
+  card: '#FFFFFF',
+  border: '#E0D8CE',
+  borderSubtle: '#EDE8E0',
+  text: '#2A2520',
+  muted: '#8A7A6A',
+  sub: '#6A5A4A',
+  accent: '#C4922A',
+  accentBg: 'rgba(196,146,42,0.10)',
+  fontFamily: "'Noto Serif JP', 'Hiragino Sans', sans-serif",
+};
+
+const S = {
+  app: {
+    maxWidth: 760, margin: '0 auto', minHeight: '100vh',
+    padding: 16, background: T.bg, color: T.text,
+    fontFamily: T.fontFamily, fontSize: 15, lineHeight: 1.6,
+  },
+  label: {
+    fontSize: 13, color: T.sub, marginBottom: 8,
+    display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+  },
+  section: { marginBottom: 22 },
+  chips: { display: 'flex', flexWrap: 'wrap', gap: 8 },
+  textarea: {
+    width: '100%', background: T.bg, border: `1px solid ${T.border}`,
+    borderRadius: 8, color: T.text, padding: '10px 12px',
+    fontSize: 13, fontFamily: 'inherit', resize: 'none',
+    outline: 'none', boxSizing: 'border-box',
+  },
+};
+
+function Chip({ label, active, onClick, disabled }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled && !active}
+      style={{
+        padding: '6px 14px', borderRadius: 20,
+        cursor: disabled && !active ? 'default' : 'pointer',
+        border: `1px solid ${active ? T.accent : T.border}`,
+        background: active ? T.accentBg : T.card,
+        color: active ? T.accent : disabled && !active ? T.border : T.sub,
+        fontSize: 13, fontWeight: active ? 600 : 400,
+        transition: 'all 0.15s',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Toast({ msg, show }) {
+  return (
+    <div style={{
+      position: 'fixed', bottom: 24, left: '50%', transform: 'translateX(-50%)',
+      background: T.accent, color: '#fff', padding: '10px 20px', borderRadius: 24,
+      fontSize: 13, fontWeight: 600,
+      opacity: show ? 1 : 0, pointerEvents: 'none',
+      transition: 'opacity 0.2s',
+      boxShadow: '0 8px 24px rgba(196,146,42,0.3)', zIndex: 100,
+    }}>
+      {msg}
+    </div>
+  );
+}
+
+const EMPTY_FORM = {
+  saikaku: [], saikakuOther: '',
+  domains: [], domainsOther: '',
+  actions: [],
+  help: '', oneworld: '',
+  talkLevel: null,
+};
+
+function formFromSaved(data) {
+  if (!data) return EMPTY_FORM;
+  const saikakuOtherEntry = (data.saikaku ?? []).find(s => s.startsWith('その他:'));
+  const domainsOtherEntry = (data.domains ?? []).find(s => s.startsWith('その他:'));
+  return {
+    saikaku: (data.saikaku ?? []).map(s => s.startsWith('その他:') ? 'その他' : s),
+    saikakuOther: saikakuOtherEntry ? saikakuOtherEntry.slice(4) : '',
+    domains: (data.domains ?? []).map(s => s.startsWith('その他:') ? 'その他' : s),
+    domainsOther: domainsOtherEntry ? domainsOtherEntry.slice(4) : '',
+    actions: data.actions ?? [],
+    help: data.help ?? '',
+    oneworld: data.oneworld ?? '',
+    talkLevel: data.talkLevel ?? null,
+  };
+}
+
+export default function ProgressInput({ user, onLogout }) {
+  const [saved, setSaved] = useState(new Map());
+  const [current, setCurrent] = useState(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState({ show: false, msg: '' });
+  const [loading, setLoading] = useState(true);
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const snap = await getDocs(collection(db, 'alpha_events', EVENT_ID, 'resonance'));
+        const map = new Map();
+        snap.forEach(d => {
+          const data = d.data();
+          if (data.fromUid === user.uid) map.set(data.toUid, data);
+        });
+        setSaved(map);
+      } catch (e) {
+        console.warn('[Progress] load error:', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [user.uid]);
+
+  const selectGroup = (g) => {
+    setCurrent(g);
+    setForm(formFromSaved(saved.get(g.id)));
+    setTimeout(() => panelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+  };
+
+  const toggleSet = (key, value, max) => {
+    setForm(f => {
+      const arr = f[key];
+      if (arr.includes(value)) return { ...f, [key]: arr.filter(v => v !== value) };
+      if (max && arr.length >= max) return f;
+      return { ...f, [key]: [...arr, value] };
+    });
+  };
+
+  const showToast = (msg) => {
+    setToast({ show: true, msg });
+    setTimeout(() => setToast({ show: false, msg: '' }), 1800);
+  };
+
+  const handleSave = async () => {
+    if (!form.talkLevel || !current) return;
+    setSaving(true);
+    try {
+      const saikakuFinal = form.saikaku.map(s =>
+        s === 'その他' ? `その他:${form.saikakuOther}` : s
+      );
+      const domainsFinal = form.domains.map(s =>
+        s === 'その他' ? `その他:${form.domainsOther}` : s
+      );
+      const data = {
+        fromUid: user.uid,
+        fromName: user.displayName || user.email || '',
+        toUid: current.id,
+        toName: current.name,
+        presenter: current.presenter,
+        saikaku: saikakuFinal,
+        domains: domainsFinal,
+        actions: form.actions,
+        help: form.help,
+        oneworld: form.oneworld,
+        talkLevel: form.talkLevel,
+        updatedAt: serverTimestamp(),
+      };
+      await setDoc(doc(db, 'alpha_events', EVENT_ID, 'resonance', `${user.uid}__${current.id}`), data);
+      setSaved(prev => new Map(prev).set(current.id, data));
+      showToast('保存しました');
+
+      const nextUnsaved = GROUPS.find(g => !saved.has(g.id) && g.id !== current.id);
+      if (nextUnsaved) {
+        setTimeout(() => selectGroup(nextUnsaved), 400);
+      } else {
+        setCurrent(null);
+      }
+    } catch (e) {
+      console.error('[Progress] save error:', e);
+      showToast('保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const progress = saved.size;
+  const total = GROUPS.length;
+
+  if (loading) {
+    return (
+      <div style={{ ...S.app, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{
+          width: 36, height: 36, borderRadius: '50%',
+          border: `3px solid ${T.border}`, borderTopColor: T.accent,
+          animation: 'spin 1s linear infinite',
+        }} />
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      </div>
+    );
+  }
+
+  return (
+    <div style={S.app}>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '12px 4px 16px', borderBottom: `1px solid ${T.border}`, marginBottom: 20,
+      }}>
+        <div>
+          <div style={{ fontSize: 18, fontWeight: 700, color: T.text }}>{EVENT_TITLE}</div>
+          <div style={{ fontSize: 11, color: T.accent, letterSpacing: '0.12em', marginTop: 2 }}>
+            RETREAT α 2026 ・ 進捗報告会 6/6
+          </div>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div style={{ fontSize: 12, color: T.muted }}>進捗 {progress}/{total}</div>
+          <button onClick={onLogout} style={{
+            background: 'transparent', border: `1px solid ${T.border}`,
+            color: T.muted, fontSize: 11, padding: '4px 10px',
+            borderRadius: 6, cursor: 'pointer',
+          }}>ログアウト</button>
+        </div>
+      </div>
+
+      {/* Group grid */}
+      <div style={{ fontSize: 11, color: T.muted, letterSpacing: '0.06em', marginBottom: 10 }}>
+        発表グループを選択 ── 各事業の発表（①進捗／②行き詰まり／③今後／④One World活用）を聞いて記入
+      </div>
+      <div style={{
+        display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
+        gap: 12, marginBottom: 24,
+      }}>
+        {GROUPS.map(g => (
+          <GroupCard
+            key={g.id}
+            group={g}
+            done={saved.has(g.id)}
+            active={current?.id === g.id}
+            onClick={() => selectGroup(g)}
+          />
+        ))}
+      </div>
+
+      {/* Input panel */}
+      {current ? (
+        <div ref={panelRef} style={{
+          background: T.card, border: `1px solid ${T.border}`,
+          borderRadius: 12, padding: 20, marginBottom: 20,
+          boxShadow: '0 2px 12px rgba(0,0,0,0.05)',
+        }}>
+          {/* Group info */}
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 14,
+            paddingBottom: 16, borderBottom: `1px solid ${T.borderSubtle}`, marginBottom: 16,
+          }}>
+            <div style={{
+              width: 56, height: 56, borderRadius: '50%',
+              background: T.bg, border: `1px solid ${T.border}`,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 24, fontWeight: 800, color: T.accent, flexShrink: 0,
+            }}>
+              {current.icon}
+            </div>
+            <div>
+              <div style={{ fontSize: 17, fontWeight: 800, color: T.text, lineHeight: 1.35 }}>{current.name}</div>
+              <div style={{ fontSize: 12, color: T.accent, marginTop: 3, fontWeight: 700 }}>
+                発表：{current.presenter}
+                {current.members && current.members.length ? `　｜　メンバー：${current.members.join('・')}` : ''}
+              </div>
+            </div>
+          </div>
+
+          {/* Talk guide */}
+          <div style={{
+            background: T.accentBg, border: '1px solid #ECE0C4', borderRadius: 10,
+            padding: '11px 14px', marginBottom: 20, fontSize: 12, color: '#7a6a3a', lineHeight: 1.7,
+          }}>
+            この発表で語られること ▶ <b>①進捗</b>（αからどう動いたか）／<b>②行き詰まり</b>（正直に）／<b>③今後の計画</b>／<b>④10/18 One World の活用法</b>。
+            特に<b>②と④</b>に「自分が力になれること」を見つけたら、それがマッチングです。
+          </div>
+
+          {/* ① 才覚で感じたもの */}
+          <div style={S.section}>
+            <div style={S.label}>
+              <span>① この事業に感じた才覚</span>
+              <span style={{ fontSize: 11, color: T.muted }}>最大3つ　{form.saikaku.length}/3</span>
+            </div>
+            <div style={S.chips}>
+              {SAIKAKU_TAGS.map(tag => (
+                <Chip
+                  key={tag} label={tag}
+                  active={form.saikaku.includes(tag)}
+                  onClick={() => toggleSet('saikaku', tag, 3)}
+                  disabled={form.saikaku.length >= 3}
+                />
+              ))}
+            </div>
+            {form.saikaku.includes('その他') && (
+              <input
+                value={form.saikakuOther}
+                onChange={e => setForm(f => ({ ...f, saikakuOther: e.target.value }))}
+                placeholder="具体的に..."
+                maxLength={40}
+                style={{
+                  marginTop: 8, width: '100%', background: T.bg,
+                  border: `1px solid ${T.border}`, borderRadius: 8,
+                  color: T.text, padding: '8px 12px', fontSize: 13,
+                  fontFamily: 'inherit', outline: 'none', boxSizing: 'border-box',
+                }}
+              />
+            )}
+          </div>
+
+          {/* ② 響いた領域 */}
+          <div style={S.section}>
+            <div style={S.label}>
+              <span>② 響いた／可能性を感じた領域</span>
+              <span style={{ fontSize: 11, color: T.muted }}>複数可</span>
+            </div>
+            <div style={S.chips}>
+              {AFFINITY_DOMAINS.map(tag => (
+                <Chip
+                  key={tag} label={tag}
+                  active={form.domains.includes(tag)}
+                  onClick={() => toggleSet('domains', tag, null)}
+                  disabled={false}
+                />
+              ))}
+            </div>
+            {form.domains.includes('その他') && (
+              <input
+                value={form.domainsOther}
+                onChange={e => setForm(f => ({ ...f, domainsOther: e.target.value }))}
+                placeholder="具体的に..."
+                maxLength={40}
+                style={{
+                  marginTop: 8, width: '100%', background: T.bg,
+                  border: `1px solid ${T.border}`, borderRadius: 8,
+                  color: T.text, padding: '8px 12px', fontSize: 13,
+                  fontFamily: 'inherit', outline: 'none', boxSizing: 'border-box',
+                }}
+              />
+            )}
+          </div>
+
+          {/* ③ この事業と… */}
+          <div style={S.section}>
+            <div style={S.label}>
+              <span>③ この事業と…</span>
+              <span style={{ fontSize: 11, color: T.muted }}>複数可</span>
+            </div>
+            <div style={S.chips}>
+              {RESONANCE_ACTIONS.map(tag => (
+                <Chip
+                  key={tag} label={tag}
+                  active={form.actions.includes(tag)}
+                  onClick={() => toggleSet('actions', tag, null)}
+                  disabled={false}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* ④ ★行き詰まりに力になれること */}
+          <div style={S.section}>
+            <div style={S.label}>
+              <span>④ ★②の行き詰まりに「私が力になれる」こと・繋げられる人</span>
+              <span style={{ fontSize: 11, color: T.muted }}>任意・マッチング</span>
+            </div>
+            <textarea
+              value={form.help}
+              onChange={e => setForm(f => ({ ...f, help: e.target.value }))}
+              maxLength={200} rows={2}
+              placeholder="例：その集客なら○○さんを紹介できる／そのシステムは私が組める..."
+              style={S.textarea}
+            />
+          </div>
+
+          {/* ⑤ ★One World活用 */}
+          <div style={S.section}>
+            <div style={S.label}>
+              <span>⑤ ★10/18 One World での活用・一緒にやれること</span>
+              <span style={{ fontSize: 11, color: T.muted }}>任意</span>
+            </div>
+            <textarea
+              value={form.oneworld}
+              onChange={e => setForm(f => ({ ...f, oneworld: e.target.value }))}
+              maxLength={200} rows={2}
+              placeholder="例：安田講堂のこの枠でこう出せる／このブースで組める..."
+              style={S.textarea}
+            />
+          </div>
+
+          {/* ⑥ 後で話したい度 */}
+          <div style={S.section}>
+            <div style={S.label}>
+              <span>⑥ 後で話したい度</span>
+              <span style={{ fontSize: 11, color: '#a84432' }}>必須</span>
+            </div>
+            <TalkLevelSelector value={form.talkLevel} onChange={v => setForm(f => ({ ...f, talkLevel: v }))} />
+          </div>
+
+          {/* Actions */}
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button
+              onClick={() => setCurrent(null)}
+              style={{
+                padding: '14px 16px', background: 'transparent', color: T.sub,
+                border: `1px solid ${T.border}`, borderRadius: 8, cursor: 'pointer', fontSize: 13,
+              }}
+            >
+              閉じる
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={!form.talkLevel || saving}
+              style={{
+                flex: 1, padding: '14px 20px',
+                background: form.talkLevel && !saving ? T.accent : T.border,
+                color: '#fff', border: 'none', borderRadius: 8,
+                fontSize: 15, fontWeight: 700,
+                cursor: form.talkLevel && !saving ? 'pointer' : 'not-allowed',
+                opacity: form.talkLevel && !saving ? 1 : 0.6,
+                transition: 'background 0.2s',
+              }}
+            >
+              {saving ? '保存中…' : '保存して次へ'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ textAlign: 'center', padding: '60px 20px', color: T.muted, fontSize: 14 }}>
+          {progress >= total ? (
+            <>
+              <div style={{ fontSize: 32, marginBottom: 12, color: T.accent, opacity: 0.7 }}>✓</div>
+              全事業分の入力が完了しました。お疲れさま。
+            </>
+          ) : (
+            <>
+              <div style={{ fontSize: 32, marginBottom: 12, opacity: 0.3 }}>◎</div>
+              上のリストから発表グループを選んで入力を始める
+            </>
+          )}
+        </div>
+      )}
+
+      <Toast msg={toast.msg} show={toast.show} />
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,10 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import AppRouter from './App.jsx';
 import AlphaApp from './alpha/AlphaApp.jsx';
+import ProgressApp from './alpha-progress/ProgressApp.jsx';
 import ErrorBoundary from './ErrorBoundary.jsx';
 import './index.css';
 
-const Root = window.location.pathname.startsWith('/alpha') ? AlphaApp : AppRouter;
+// /alpha-progress は /alpha を prefix に含むため、必ず先に判定する
+const path = window.location.pathname;
+const Root = path.startsWith('/alpha-progress') ? ProgressApp
+  : path.startsWith('/alpha') ? AlphaApp
+  : AppRouter;
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## 概要
6/6 RETREAT α 進捗報告会の事業マッチング共鳴シートを公開ウェブアプリ化（Drive引き継ぎ依頼）。既存 `/alpha`（人単位23名・本番稼働中）は**無改変**で、別ルート `/alpha-progress`・別イベントID `retreat-alpha-progress-2026-0606` で新設。

## 変更
- 新規 `src/alpha-progress/`（data.js / ProgressApp / ProgressInput / ProgressAdmin / GroupCard）
- `src/main.jsx` のみ既存変更（`/alpha-progress` を `/alpha` より先に判定する1分岐追加）
- 認証(Google+メール)/Firestore/TalkLevelSelector は既存 src/alpha を import 流用
- 15事業グループ単位フォーム（①才覚 ②領域13項目 ③この事業と ④行き詰まり力 ⑤OneWorld活用 ⑥話したい度）
- 進捗 total=GROUPS.length（人単位 -1 バグ回避）、map import/分岐は除去
- 集計+CSV（Drive README列準拠）

## 検証
- plan-with-debate（Codex+Gemini+Claude独立）→ fact-check 反映
- ローカル Firebase emulator E2E **14/14 + 保存スキーマ検証**（toUid=g01 / oneworld / talkLevel / fromUid / presenter）
- 未認証 read は firestore.rules で拒否を確認
- `npm run build` 成功、既存 src/alpha/* の diff は無し（main.jsx のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)