### PR TITLE
feat(alpha-progress): 発表一覧を20事業に更新

### DIFF
--- a/src/alpha-progress/components/GroupCard.jsx
+++ b/src/alpha-progress/components/GroupCard.jsx
@@ -37,9 +37,11 @@ export default function GroupCard({ group, done, active, onClick }) {
         <div style={{ fontSize: 14.5, fontWeight: 800, color: '#2A2520', lineHeight: 1.35 }}>
           {group.name}
         </div>
-        <div style={{ fontSize: 11.5, color: '#9C7D18', marginTop: 5, fontWeight: 700 }}>
-          発表：{group.presenter}
-        </div>
+        {group.presenter && (
+          <div style={{ fontSize: 11.5, color: '#9C7D18', marginTop: 5, fontWeight: 700 }}>
+            発表：{group.presenter}
+          </div>
+        )}
         <div style={{ fontSize: 11, color: '#8A7A6A', marginTop: 3, lineHeight: 1.4 }}>
           {members}
         </div>

--- a/src/alpha-progress/data.js
+++ b/src/alpha-progress/data.js
@@ -1,30 +1,36 @@
 // α進捗報告会 共鳴シート（6/6）データ定義
-// 出典: Drive「回答フォーム（html)」/ α進捗報告会_共鳴シート_v1.0.html の GROUPS 定数（base64原本をデコードして移植）
-// 既存 src/alpha/uaam16.js（人単位23名）とは別物。こちらは事業単位15グループ。
+// 出典: つかさ指定の発表一覧（2026-06-06更新, 20事業）。Drive「回答フォーム（html)」を上書き。
+// 既存 src/alpha/uaam16.js（人単位23名）とは別物。こちらは事業単位グループ。
 
 export const EVENT_ID = 'retreat-alpha-progress-2026-0606';
 
 export const EVENT_TITLE = 'α進捗報告会 共鳴シート';
 export const EVENT_SUBTITLE = 'RETREAT α 2026 ・ 進捗報告会 6/6';
 
-// 15 事業グループ（id, icon, name, presenter, members）
+// 発表グループ（id, icon, name, presenter, members）
 // 各事業は「①進捗 / ②行き詰まり / ③今後 / ④One World活用」を発表する
+// ※ icon の蝶/星/地/智/時（g15-g17,g19,g20）はクロード仮置き。差し替え可
 export const GROUPS = [
   { id: 'g01', icon: '祈', name: '日常生活に祈りを取り戻すAI大和風水プロジェクト', presenter: '長田広美', members: ['林司', '小嶋勇治', '野田健一', '勝屋裕貴'] },
-  { id: 'g02', icon: '學', name: '学童保育プロジェクト', presenter: '飯塚玄氣・長田広美', members: ['宇田川昌美（欠席）'] },
+  { id: 'g02', icon: '學', name: '學童保育プロジェクト', presenter: '飯塚玄氣・長田広美', members: ['宇田川昌美（欠席）'] },
   { id: 'g03', icon: '🍯', name: 'はちみつプロジェクト', presenter: '杉永竜之助', members: ['鈴木栄子', 'haru', '奈都'] },
   { id: 'g04', icon: '⭐️', name: 'クラファンプロジェクト', presenter: '山永彩葵', members: ['杉永竜之助', '飯塚玄氣', '小嶋勇治'] },
-  { id: 'g05', icon: '虹', name: 'LGBTの次の時代のロールモデル創出プロジェクト（仮）', presenter: '坂口友亮', members: [] },
+  { id: 'g05', icon: '虹', name: 'LGBTの次の時代のロールモデル創出プロジェクト（仮名）', presenter: '坂口友亮', members: [] },
   { id: 'g06', icon: '香', name: 'バーム開発', presenter: '細川さゆり', members: ['奈都'] },
   { id: 'g07', icon: '保', name: '保険募集人から日本を大丈夫に', presenter: '原田祐介', members: ['道又正人'] },
   { id: 'g08', icon: 'AI', name: '業界リーディングカンパニーのAIトランスフォーメーション', presenter: '藤原宗賢', members: ['塚原厚'] },
   { id: 'g09', icon: '祭', name: 'アーティスト祭（仮）', presenter: '浜口奈々', members: [] },
   { id: 'g10', icon: '♪', name: 'ハミングプロジェクト', presenter: '根木マリサ', members: [] },
   { id: 'g11', icon: '寺', name: '全国の無縁仏を解消しお寺の保全へ 墓地環境保全事業部', presenter: '遠山直樹', members: ['奈都', '石井裕二'] },
-  { id: 'g12', icon: '司', name: '国作り事業をサポートする作戦司令部設立及び新会社設立', presenter: '遠山直樹', members: ['奈都', 'haru'] },
+  { id: 'g12', icon: '司', name: '國作り事業をサポートする作戦司令部設立及び新会社設立', presenter: '遠山直樹', members: ['奈都', 'haru'] },
   { id: 'g13', icon: '腸', name: '腸活健康イノベーション', presenter: '根本輝尚', members: ['奈都', 'haru', '藤田明日香（補佐）', '岩田和真（補佐）'] },
   { id: 'g14', icon: '雅', name: '神社交界・雅の会', presenter: '藤田由美子', members: ['奈都'] },
-  { id: 'g15', icon: '麻', name: '神社、ヘンププロジェクト', presenter: '島田知幸（発表・動画）', members: ['奈都'] },
+  { id: 'g15', icon: '蝶', name: 'ごまめ変容プロジェクト', presenter: '谷口尚子', members: ['haru', '澤井ひろき', '藤原宗賢', '塚原厚', '島田知幸'] },
+  { id: 'g16', icon: '星', name: 'ホストイメージアップ戦略', presenter: '藤田由美子', members: ['奈都', '藤田明日香（欠席）', '岩田和真'] },
+  { id: 'g17', icon: '地', name: '地域資産価値向上 名古屋チームとの連携', presenter: '秋葉勇人', members: [] },
+  { id: 'g18', icon: '麻', name: '神社、ヘンププロジェクト', presenter: '島田知幸（発表・動画）', members: ['奈都'] },
+  { id: 'g19', icon: '智', name: 'AIチーム', presenter: '勝屋裕貴', members: ['林司', '小嶋勇治', '野田健一'] },
+  { id: 'g20', icon: '時', name: 'クロノス', presenter: '', members: [] },
 ];
 
 // ① この事業に感じた才覚（最大3）
@@ -34,7 +40,7 @@ export const SAIKAKU_TAGS = [
   '専門性', '世界観', '熱量', '信頼感', 'その他',
 ];
 
-// ② 響いた／可能性を感じた領域（複数可）。Drive原本準拠で13項目（公益財団・One World を含む）
+// ② 響いた／可能性を感じた領域（複数可）。13項目（公益財団・One World を含む）
 export const AFFINITY_DOMAINS = [
   'AI', '教育', '地域活性', '芸術・表現', 'チームビルディング',
   'コミュニティ', '経営', '福祉', '国際', 'SNS',

--- a/src/alpha-progress/pages/ProgressInput.jsx
+++ b/src/alpha-progress/pages/ProgressInput.jsx
@@ -269,10 +269,12 @@ export default function ProgressInput({ user, onLogout }) {
             </div>
             <div>
               <div style={{ fontSize: 17, fontWeight: 800, color: T.text, lineHeight: 1.35 }}>{current.name}</div>
-              <div style={{ fontSize: 12, color: T.accent, marginTop: 3, fontWeight: 700 }}>
-                発表：{current.presenter}
-                {current.members && current.members.length ? `　｜　メンバー：${current.members.join('・')}` : ''}
-              </div>
+              {(current.presenter || (current.members && current.members.length > 0)) && (
+                <div style={{ fontSize: 12, color: T.accent, marginTop: 3, fontWeight: 700 }}>
+                  {current.presenter ? `発表：${current.presenter}` : ''}
+                  {current.members && current.members.length ? `${current.presenter ? '　｜　' : ''}メンバー：${current.members.join('・')}` : ''}
+                </div>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
つかさ指定の発表一覧（20事業）に更新。新規5事業追加＋表記修正。id g01-g20振り直し（実データ無し）。発表者未指定(クロノス)の表示ガード追加。build通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)